### PR TITLE
Fix 2 small packet exploits

### DIFF
--- a/src/main/java/net/server/channel/handlers/SkillMacroHandler.java
+++ b/src/main/java/net/server/channel/handlers/SkillMacroHandler.java
@@ -21,24 +21,35 @@
 */
 package net.server.channel.handlers;
 
+import client.MapleCharacter;
 import client.MapleClient;
 import client.SkillMacro;
-import tools.data.input.SeekableLittleEndianAccessor;
+import client.autoban.AutobanFactory;
 import net.AbstractMaplePacketHandler;
+import tools.data.input.SeekableLittleEndianAccessor;
 
 public final class SkillMacroHandler extends AbstractMaplePacketHandler {
-    
+
     @Override
     public final void handlePacket(SeekableLittleEndianAccessor slea, MapleClient c) {
+        MapleCharacter chr = c.getPlayer();
         int num = slea.readByte();
+        if (num > 5) return;
+
         for (int i = 0; i < num; i++) {
             String name = slea.readMapleAsciiString();
+            if (name.length() > 12) {
+                AutobanFactory.PACKET_EDIT.alert(chr, "Invalid name length " + name + " (" + name.length() + ") for skill macro.");
+                c.disconnect(false, false);
+                break;
+            }
+
             int shout = slea.readByte();
             int skill1 = slea.readInt();
             int skill2 = slea.readInt();
             int skill3 = slea.readInt();
             SkillMacro macro = new SkillMacro(skill1, skill2, skill3, name, shout, i);
-            c.getPlayer().updateMacros(i, macro);
+            chr.updateMacros(i, macro);
         }
     }
 }


### PR DESCRIPTION
These exploits cause MapleCharacter.saveToDB() to fail which result in a rollback, players will be able to dupe by dropping the items on the ground before logging off.