### PR TITLE
Allow local/LAN/WAN login-phase connections

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -199,8 +199,9 @@ server:
     LOGIN_ATTEMPT_DURATION: 120         #Period in seconds the login attempt remains registered on the system.
 
     #Ip Configuration
-    HOST: 127.0.0.1
-    LOCALSERVER: true
+    HOST: 127.0.0.1                 #WAN IPv4 address
+    LANHOST: 127.0.0.1              #LAN IPv4 address
+    LOCALHOST: 127.0.0.1            #Loopback IPv4 address
     GMSERVER: false
 
     #Other configuration

--- a/src/main/java/client/MapleClient.java
+++ b/src/main/java/client/MapleClient.java
@@ -1341,7 +1341,7 @@ public class MapleClient {
 			return;
                 }
                 
-                String[] socket = Server.getInstance().getInetSocket(getWorld(), channel);
+                String[] socket = Server.getInstance().getInetSocket(this.getSession(), getWorld(), channel);
                 if(socket == null) {
                         announce(MaplePacketCreator.serverNotice(1, "Channel " + channel + " is currently disabled. Try another channel."));
                         announce(MaplePacketCreator.enableActions());

--- a/src/main/java/client/command/commands/gm6/WarpWorldCommand.java
+++ b/src/main/java/client/command/commands/gm6/WarpWorldCommand.java
@@ -49,7 +49,7 @@ public class WarpWorldCommand extends Command {
         byte worldb = Byte.parseByte(params[0]);
         if (worldb <= (server.getWorldsSize() - 1)) {
             try {
-                String[] socket = server.getInetSocket(worldb, c.getChannel());
+                String[] socket = server.getInetSocket(c.getSession(), worldb, c.getChannel());
                 c.getWorldServer().removePlayer(player);
                 player.getMap().removePlayer(player);//LOL FORGOT THIS ><
                 player.setSessionTransitionState();

--- a/src/main/java/config/ServerConfig.java
+++ b/src/main/java/config/ServerConfig.java
@@ -44,7 +44,8 @@ public class ServerConfig {
 
     //Ip Configuration
     public String HOST;
-    public boolean LOCALSERVER;
+    public String LANHOST;
+    public String LOCALHOST;
     public boolean GMSERVER;
 
     //Other configuration

--- a/src/main/java/net/MapleServerHandler.java
+++ b/src/main/java/net/MapleServerHandler.java
@@ -103,6 +103,8 @@ public class MapleServerHandler extends IoHandlerAdapter {
             
             if (remoteHost == null) {
                 remoteHost = "null";
+            } else {
+                remoteHost = MapleSessionCoordinator.fetchRemoteAddress(remoteHost);   // thanks dyz for noticing Local/LAN/WAN connections not interacting properly
             }
         } catch (NullPointerException npe) {    // thanks Agassy, Alchemist for pointing out possibility of remoteHost = null.
             remoteHost = "null";

--- a/src/main/java/net/server/Server.java
+++ b/src/main/java/net/server/Server.java
@@ -56,6 +56,7 @@ import org.apache.mina.core.buffer.IoBuffer;
 import org.apache.mina.core.buffer.SimpleBufferAllocator;
 import org.apache.mina.core.service.IoAcceptor;
 import org.apache.mina.core.session.IdleStatus;
+import org.apache.mina.core.session.IoSession;
 import org.apache.mina.filter.codec.ProtocolCodecFilter;
 import org.apache.mina.transport.socket.nio.NioSocketAcceptor;
 import org.slf4j.Logger;
@@ -285,8 +286,7 @@ public class Server {
         }
     }
 
-    public String[] getInetSocket(int world, int channel) {
-        public String[] getInetSocket(IoSession session, int world, int channel) {
+    public String[] getInetSocket(IoSession session, int world, int channel) {
         String remoteIp = MapleSessionCoordinator.getSessionRemoteAddress(session);
 
         String[] hostAddress = getIP(world, channel).split(":");

--- a/src/main/java/net/server/Server.java
+++ b/src/main/java/net/server/Server.java
@@ -286,8 +286,18 @@ public class Server {
     }
 
     public String[] getInetSocket(int world, int channel) {
+        public String[] getInetSocket(IoSession session, int world, int channel) {
+        String remoteIp = MapleSessionCoordinator.getSessionRemoteAddress(session);
+
+        String[] hostAddress = getIP(world, channel).split(":");
+        if (MapleSessionCoordinator.isLocalAddress(remoteIp)) {
+            hostAddress[0] = YamlConfig.config.server.LOCALHOST;
+        } else if (MapleSessionCoordinator.isLanAddress(remoteIp)) {
+            hostAddress[0] = YamlConfig.config.server.LANHOST;
+        }
+
         try {
-            return getIP(world, channel).split(":");
+            return hostAddress;
         } catch (Exception e) {
             return null;
         }

--- a/src/main/java/net/server/coordinator/session/MapleSessionCoordinator.java
+++ b/src/main/java/net/server/coordinator/session/MapleSessionCoordinator.java
@@ -38,6 +38,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  *

--- a/src/main/java/net/server/handlers/login/CharSelectedHandler.java
+++ b/src/main/java/net/server/handlers/login/CharSelectedHandler.java
@@ -94,7 +94,7 @@ public final class CharSelectedHandler extends AbstractMaplePacketHandler {
             return;
         }
         
-        String[] socket = server.getInetSocket(c.getWorld(), c.getChannel());
+        String[] socket = server.getInetSocket(session, c.getWorld(), c.getChannel());
         if(socket == null) {
             c.announce(MaplePacketCreator.getAfterLoginError(10));
             return;

--- a/src/main/java/net/server/handlers/login/CharSelectedWithPicHandler.java
+++ b/src/main/java/net/server/handlers/login/CharSelectedWithPicHandler.java
@@ -71,7 +71,7 @@ public class CharSelectedWithPicHandler extends AbstractMaplePacketHandler {
                 return;
             }
             
-            String[] socket = server.getInetSocket(c.getWorld(), c.getChannel());
+            String[] socket = server.getInetSocket(session, c.getWorld(), c.getChannel());
             if(socket == null) {
                 c.announce(MaplePacketCreator.getAfterLoginError(10));
                 return;

--- a/src/main/java/net/server/handlers/login/LoginPasswordHandler.java
+++ b/src/main/java/net/server/handlers/login/LoginPasswordHandler.java
@@ -61,21 +61,7 @@ public final class LoginPasswordHandler implements MaplePacketHandler {
     @Override
     public final void handlePacket(SeekableLittleEndianAccessor slea, MapleClient c) {
         String remoteHost = getRemoteIp(c.getSession());
-        if (!remoteHost.contentEquals("null")) {
-            if (YamlConfig.config.server.USE_IP_VALIDATION) {    // thanks Alex-0000 (CanIGetaPR) for suggesting IP validation as a server flag
-                if (remoteHost.startsWith("127.")) {
-                    if (!YamlConfig.config.server.LOCALSERVER) { // thanks Mills for noting HOST can also have a field named "localhost"
-                        c.announce(MaplePacketCreator.getLoginFailed(13));  // cannot login as localhost if it's not a local server
-                        return;
-                    }
-                } else {
-                    if (YamlConfig.config.server.LOCALSERVER) {
-                        c.announce(MaplePacketCreator.getLoginFailed(13));  // cannot login as non-localhost if it's a local server
-                        return;
-                    }
-                }
-            }
-        } else {
+        if (remoteHost.contentEquals("null")) {
             c.announce(MaplePacketCreator.getLoginFailed(14));          // thanks Alchemist for noting remoteHost could be null
             return;
         }

--- a/src/main/java/net/server/handlers/login/RegisterPicHandler.java
+++ b/src/main/java/net/server/handlers/login/RegisterPicHandler.java
@@ -79,7 +79,7 @@ public final class RegisterPicHandler extends AbstractMaplePacketHandler {
                 return;
             }
             
-            String[] socket = server.getInetSocket(c.getWorld(), c.getChannel());
+            String[] socket = server.getInetSocket(session, c.getWorld(), c.getChannel());
             if(socket == null) {
                 c.announce(MaplePacketCreator.getAfterLoginError(10));
                 return;

--- a/src/main/java/net/server/handlers/login/ViewAllCharRegisterPicHandler.java
+++ b/src/main/java/net/server/handlers/login/ViewAllCharRegisterPicHandler.java
@@ -82,7 +82,7 @@ public final class ViewAllCharRegisterPicHandler extends AbstractMaplePacketHand
         String pic = slea.readMapleAsciiString();
         c.setPic(pic);
         
-        String[] socket = server.getInetSocket(c.getWorld(), channel);
+        String[] socket = server.getInetSocket(session, c.getWorld(), channel);
         if (socket == null) {
             c.announce(MaplePacketCreator.getAfterLoginError(10));
             return;

--- a/src/main/java/net/server/handlers/login/ViewAllCharSelectedHandler.java
+++ b/src/main/java/net/server/handlers/login/ViewAllCharSelectedHandler.java
@@ -105,7 +105,7 @@ public final class ViewAllCharSelectedHandler extends AbstractMaplePacketHandler
             c.setChannel(1);
         }
         
-        String[] socket = server.getInetSocket(c.getWorld(), c.getChannel());
+        String[] socket = server.getInetSocket(session, c.getWorld(), c.getChannel());
         if(socket == null) {
             c.announce(MaplePacketCreator.getAfterLoginError(10));
             return;

--- a/src/main/java/net/server/handlers/login/ViewAllCharSelectedWithPicHandler.java
+++ b/src/main/java/net/server/handlers/login/ViewAllCharSelectedWithPicHandler.java
@@ -77,7 +77,7 @@ public class ViewAllCharSelectedWithPicHandler extends AbstractMaplePacketHandle
         c.setChannel(channel);
         
         if (c.checkPic(pic)) {
-            String[] socket = server.getInetSocket(c.getWorld(), c.getChannel());
+            String[] socket = server.getInetSocket(session, c.getWorld(), c.getChannel());
             if(socket == null) {
                 c.announce(MaplePacketCreator.getAfterLoginError(10));
                 return;


### PR DESCRIPTION
Allow clients connecting from different IP domains (local/LAN/WAN) to get past login phase and clean unnecessary local server check.