### PR TITLE
Clear old job quests on rebirth

### DIFF
--- a/scripts/npc/1012100.js
+++ b/scripts/npc/1012100.js
@@ -1,8 +1,8 @@
 /*
-	This file is part of the OdinMS Maple Story Server
+    This file is part of the OdinMS Maple Story Server
     Copyright (C) 2008 Patrick Huy <patrick.huy@frz.cc>
-		       Matthias Butz <matze@odinms.de>
-		       Jan Christian Meyer <vimes@odinms.de>
+               Matthias Butz <matze@odinms.de>
+               Jan Christian Meyer <vimes@odinms.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Affero General Public License as
@@ -21,8 +21,8 @@
 */
 
 /*      Athena Pierce
-	Bowman Job Advancement
-	Victoria Road : Bowman Instructional School (100000201)
+    Bowman Job Advancement
+    Victoria Road : Bowman Instructional School (100000201)
 */
 
 status = -1;
@@ -51,7 +51,7 @@ function start() {
             actionx["2ndJob"] = true;
             if (cm.haveItem(4031012))
                 cm.sendNext("Haha...I knew you'd breeze through that test. I'll admit, you are a great bowman. I'll make you much stronger than you're right now. before that, however... you;ll need to choose one of two paths given to you. It'll be a difficult decision for you to make, but... if there's any question to ask, please do so.");
-            else if (cm.haveItem(4031011)){
+            else if (cm.haveItem(4031011)) {
                 cm.sendOk("Go and see the #b#p1072002##k.");
                 cm.dispose();
             } else
@@ -107,7 +107,7 @@ function action(mode, type, selection) {
             if (mode != 1 || status == 7 && type != 1 || (actionx["1stJob"] && status == 4) || (cm.haveItem(4031008) && status == 2) || (actionx["3thJobI"] && status == 1)){
                 if (mode == 0 && status == 2 && type == 1)
                     cm.sendOk("You know there is no other choice...");
-                if (!(mode == 0 && type != 1)){
+                if (!(mode == 0 && type != 1)) {
                     cm.dispose();
                     return;
                 }
@@ -115,7 +115,7 @@ function action(mode, type, selection) {
         }
     }
     
-    if (actionx["1stJob"]){
+    if (actionx["1stJob"]) {
         if (status == 0) {
             if (cm.getLevel() >= 10 && cm.canGetFirstJob(jobType)) {
                 cm.sendNextPrev("It is an important and final choice. You will not be able to turn back.");
@@ -138,7 +138,7 @@ function action(mode, type, selection) {
             }
         } else if (status == 2) 
             cm.sendNextPrev("You've gotten much stronger now. Plus every single one of your inventories have added slots. A whole row, to be exact. Go see for it yourself. I just gave you a little bit of #bSP#k. When you open up the #bSkill#k menu on the lower left corner of the screen, there are skills you can learn by using SP's. One warning, though: You can't raise it all together all at once. There are also skills you can acquire only after having learned a couple of skills first.");
-	else if (status == 3)
+    else if (status == 3)
             cm.sendNextPrev("Now a reminder. Once you have chosen, you cannot change up your mind and try to pick another path. Go now, and live as a proud Bowman.");
         else
             cm.dispose();    
@@ -148,16 +148,16 @@ function action(mode, type, selection) {
                 cm.sendSimple("Alright, when you have made your decision, click on [I'll choose my occupation] at the bottom.#b\r\n#L0#Please explain to me what being the Hunter is all about.\r\n#L1#Please explain to me what being the Crossbowman is all about.\r\n#L3#I'll choose my occupation!");
             else {
                 cm.sendNext("Good decision. You look strong, but I need to see if you really are strong enough to pass the test, it's not a difficult test, so you'll do just fine. Here, take my letter first... make sure you don't lose it!");
-		if(!cm.isQuestStarted(100000)) cm.startQuest(100000);
-	   }
+        if(!cm.isQuestStarted(32000)) cm.startQuest(32000);
+       }
         } else if (status == 1){
             if (!cm.haveItem(4031012)){
                 if (cm.canHold(4031010)){
                     if (!cm.haveItem(4031010))
                         cm.gainItem(4031010, 1);
                     cm.sendNextPrev("Please get this letter to #b#p1072002##k who's around #b#m106010000##k near Henesys. She is taking care of the job of an instructor in place of me. Give her the letter and she'll test you in place of me. Best of luck to you.");
-		    cm.dispose();
-		} else {
+                    cm.dispose();
+                } else {
                     cm.sendNext("Please, make some space in your inventory.");
                     cm.dispose();
                 }
@@ -179,6 +179,7 @@ function action(mode, type, selection) {
         } else if (status == 3){
             if (cm.haveItem(4031012))
                 cm.gainItem(4031012, -1);
+            cm.completeQuest(32002);
             
             cm.sendNext("Alright, you're the " + (job == 310 ? "#bHunter#k" : "#bCrossbowman#k") + " from here on out. " + (job == 310 ? "#bHunter#k" : "#bCrossbowman#k") + "s are the intelligent bunch with incredible vision, able to pierce the arrow through the heart of the monsters with ease... please train yourself each and everyday. I'll help you become even stronger than you already are.");
             if (cm.getJobId() != job)

--- a/scripts/npc/1022000.js
+++ b/scripts/npc/1022000.js
@@ -148,7 +148,7 @@ function action(mode, type, selection) {
                 cm.sendSimple("Alright, when you have made your decision, click on [I'll choose my occupation] at the bottom.#b\r\n#L0#Please explain to me what being the Fighter is all about.\r\n#L1#Please explain to me what being the Page is all about.\r\n#L2#Please explain to me what being the Spearman is all about.\r\n#L3#I'll choose my occupation!");
             else {
                 cm.sendNext("Good decision. You look strong, but I need to see if you really are strong enough to pass the test, it's not a difficult test, so you'll do just fine. Here, take my letter first... make sure you don't lose it!");
-		if(!cm.isQuestStarted(100003)) cm.startQuest(100003);
+		if(!cm.isQuestStarted(32003)) cm.startQuest(32003);
 	    }
         } else if (status == 1){
             if (!cm.haveItem(4031012)){
@@ -184,7 +184,7 @@ function action(mode, type, selection) {
         } else if (status == 3){
             if (cm.haveItem(4031012))
                 cm.gainItem(4031012, -1);
-	    cm.completeQuest(100005);
+	    cm.completeQuest(32005);
             
             if(job == 110) cm.sendNext("Alright, you have now become the #bFighter#k. A fighter strives to become the strongest of the strong, and never stops fighting. Don't ever lose that will to fight, and push forward 24/7. I'll help you become even stronger than you already are.");
             else if(job == 120) cm.sendNext("Alright, you have now become a #bPage#k! Pages have high intelligence and bravery, which I hope you'll employ throughout your journey to the right path. I'll help you become much stronger than you already are.");

--- a/scripts/npc/1032001.js
+++ b/scripts/npc/1032001.js
@@ -152,7 +152,7 @@ function action(mode, type, selection) {
                 cm.sendSimple("Alright, when you have made your decision, click on [I'll choose my occupation] at the bottom.#b\r\n#L0#Please explain to me what being the Wizard (Fire / Poison) is all about.\r\n#L1#Please explain to me what being the Wizard (Ice / Lighting) is all about.\r\n#L2#Please explain to me what being the Cleric is all about.\r\n#L3#I'll choose my occupation!");
             else {
                 cm.sendNext("Good decision. You look strong, but I need to see if you really are strong enough to pass the test, it's not a difficult test, so you'll do just fine. Here, take my letter first... make sure you don't lose it!");
-		if(!cm.isQuestStarted(100006)) cm.startQuest(100006);
+		if(!cm.isQuestStarted(32006)) cm.startQuest(32006);
 	    }
         } else if (status == 1){
             if (!cm.haveItem(4031012)){
@@ -188,7 +188,7 @@ function action(mode, type, selection) {
         } else if (status == 3){
             if (cm.haveItem(4031012))
                 cm.gainItem(4031012, -1);
-            cm.completeQuest(100008);
+            cm.completeQuest(32008);
             cm.sendNext("Alright, you're the " + (job == 210 ? "#bWizard (Fire / Poison)#k" : job == 220 ? "#bWizard (Ice / Lighting)#k" : "#bCleric#k") + " from here on out. Mages and wizards are the intelligent bunch with incredible magical prowess, able to pierce the mind and the psychological structure of the monsters with ease... please train yourself each and everyday. I'll help you become even stronger than you already are.");
             if (cm.getJobId() != job)
                 cm.changeJobById(job);

--- a/scripts/npc/1052001.js
+++ b/scripts/npc/1052001.js
@@ -151,7 +151,7 @@ function action(mode, type, selection) {
                 cm.sendSimple("Alright, when you have made your decision, click on [I'll choose my occupation] at the bottom.#b\r\n#L0#Please explain to me what being the Assassin is all about.\r\n#L1#Please explain to me what being the Bandit is all about.\r\n#L3#I'll choose my occupation!");
             else {
                 cm.sendNext("Good decision. You look strong, but I need to see if you really are strong enough to pass the test, it's not a difficult test, so you'll do just fine. Here, take my letter first... make sure you don't lose it!");
-		if(!cm.isQuestStarted(100009)) cm.startQuest(100009);
+		if(!cm.isQuestStarted(32009)) cm.startQuest(32009);
 	    }
         } else if (status == 1){
             if (!cm.haveItem(4031012)){
@@ -185,7 +185,7 @@ function action(mode, type, selection) {
         } else if (status == 3){
             if (cm.haveItem(4031012))
                 cm.gainItem(4031012, -1);
-	    cm.completeQuest(100011);
+	    cm.completeQuest(32011);
             
             if(job == 410) cm.sendNext("Alright, from here on out you are the #bAssassin#k. Assassins have quick hands and quicker feets to dominate the enemies. Please keep training. I'll make you even more powerful than you are right now!");
             else cm.sendNext("Alright, you're the #bBandit from here on out. Bandits revel in shadows and darkness, waiting until the right time comes for them to stick a dagger through the enemy's hearth, suddenly and swiftly... please keep training. I'll make you even more powerful than you are right now.");

--- a/scripts/npc/1072000.js
+++ b/scripts/npc/1072000.js
@@ -45,13 +45,13 @@ function action(mode, type, selection) {
                         status--;
     
                 if(status == 0) {
-                        if (cm.isQuestCompleted(100004)) {
+                        if (cm.isQuestCompleted(32004)) {
                             cm.sendOk("You're truly a hero!");
                             cm.dispose();
-                        } else if(cm.isQuestCompleted(100003)) {
+                        } else if(cm.isQuestCompleted(32003)) {
                             cm.sendNext("Alright I'll let you in! Defeat the monsters inside, collect 30 Dark Marbles, then strike up a conversation with a colleague of mine inside. He'll give you #bThe Proof of a Hero#k, the proof that you've passed the test. Best of luck to you.");
                             status = 4;
-                        } else if (cm.isQuestStarted(100003)) {
+                        } else if (cm.isQuestStarted(32003)) {
                             cm.sendNext("Hmmm...it is definitely the letter from #bDances with Balrog#k...so you came all the way here to take the test and make the 2nd job advancement as the warrior. Alright, I'll explain the test to you. Don't sweat it too much, it's not that complicated.");
                         } else {
                             cm.sendOk("I can show you the way once your ready for it.");
@@ -66,8 +66,8 @@ function action(mode, type, selection) {
                         cm.sendYesNo("Once you go inside, you can't leave until you take care of your mission. If you die, your experience level will decrease..so you better really buckle up and get ready...well, do you want to go for it now?");
                 else if (status == 4) {
                         cm.sendNext("Alright I'll let you in! Defeat the monsters inside, collect 30 Dark Marbles, then strike up a conversation with a colleague of mine inside. He'll give you #bThe Proof of a Hero#k, the proof that you've passed the test. Best of luck to you.");
-                        cm.completeQuest(100003);
-                        cm.startQuest(100004);
+                        cm.completeQuest(32003);
+                        cm.startQuest(32004);
                         cm.gainItem(4031008, -1);
                 }
                 else if (status == 5) {

--- a/scripts/npc/1072001.js
+++ b/scripts/npc/1072001.js
@@ -45,13 +45,13 @@ function action(mode, type, selection) {
                         status--;
     
                 if(status == 0) {
-                        if (cm.isQuestCompleted(100007)) {
+                        if (cm.isQuestCompleted(32007)) {
                             cm.sendOk("You're truly a hero!");
                             cm.dispose();
-                        } else if(cm.isQuestCompleted(100006)) {
+                        } else if(cm.isQuestCompleted(32006)) {
                             cm.sendNext("Alright I'll let you in! Defeat the monsters inside, collect 30 Dark Marbles, then strike up a conversation with a colleague of mine inside. He'll give you #bThe Proof of a Hero#k, the proof that you've passed the test. Best of luck to you.");
                             status = 4;
-                        } else if (cm.isQuestStarted(100006)) {
+                        } else if (cm.isQuestStarted(32006)) {
                             cm.sendNext("Hmmm...it is definitely the letter from #bGrendell the Really Old#k...so you came all the way here to take the test and make the 2nd job advancement as a magician. Alright, I'll explain the test to you. Don't sweat it too much, it's not that complicated.");
                         } else {
                             cm.sendOk("I can show you the way once your ready for it.");
@@ -66,8 +66,8 @@ function action(mode, type, selection) {
                         cm.sendYesNo("Once you go inside, you can't leave until you take care of your mission. If you die, your experience level will decrease.. So you better really buckle up and get ready...well, do you want to go for it now?");
                 else if (status == 4) {
                         cm.sendNext("Alright I'll let you in! Defeat the monsters inside, collect 30 Dark Marbles, then strike up a conversation with a colleague of mine inside. He'll give you #bThe Proof of a Hero#k, the proof that you've passed the test. Best of luck to you.");
-                        cm.completeQuest(100006);            
-                        cm.startQuest(100007);
+                        cm.completeQuest(32006);
+                        cm.startQuest(32007);
                         cm.gainItem(4031009, -1);
                 }
                 else if (status == 5) {

--- a/scripts/npc/1072002.js
+++ b/scripts/npc/1072002.js
@@ -45,13 +45,13 @@ function action(mode, type, selection) {
                         status--;
     
                 if (status == 0) {
-                        if (cm.isQuestCompleted(100001)) {
+                        if (cm.isQuestCompleted(32001)) {
                             cm.sendOk("You're truly a hero!");
                             cm.dispose();
-                        } else if(cm.isQuestCompleted(100000)) {
+                        } else if(cm.isQuestCompleted(32000)) {
                             cm.sendNext("Alright I'll let you in! Defeat the monsters inside, collect 30 Dark Marbles, then strike up a conversation with a colleague of mine inside. He'll give you #bThe Proof of a Hero#k, the proof that you've passed the test. Best of luck to you.");
                             status = 3;
-                        } else if (cm.isQuestStarted(100000)) {
+                        } else if (cm.isQuestStarted(32000)) {
                             cm.sendNext("Oh, isn't this a letter from #bAthena#k?");
                         } else {
                             cm.sendOk("I can show you the way once your ready for it.");
@@ -64,8 +64,8 @@ function action(mode, type, selection) {
                 else if (status == 2)
                     cm.sendAcceptDecline("I will give you a chance if you're ready.");
                 else if (status == 3) {
-                    cm.completeQuest(100000);
-                    cm.startQuest(100001);
+                    cm.completeQuest(32000);
+                    cm.startQuest(32001);
                     cm.gainItem(4031010, -1);
                     cm.sendOk("You will have to collect me #b30 #t4031013##k. Good luck.")
                 } else if (status == 4) {

--- a/scripts/npc/1072003.js
+++ b/scripts/npc/1072003.js
@@ -45,13 +45,13 @@ function action(mode, type, selection) {
                         status--;
     
                 if(status == 0) {
-                        if (cm.isQuestCompleted(100010)) {
+                        if (cm.isQuestCompleted(32010)) {
                             cm.sendOk("You're truly a hero!");
                             cm.dispose();
-                        } else if(cm.isQuestCompleted(100009)) {
+                        } else if(cm.isQuestCompleted(32009)) {
                             cm.sendNext("Alright I'll let you in! Defeat the monsters inside, collect 30 Dark Marbles, then strike up a conversation with a colleague of mine inside. He'll give you #bThe Proof of a Hero#k, the proof that you've passed the test. Best of luck to you.");
                             status = 3;
-                        } else if (cm.isQuestStarted(100009)) {
+                        } else if (cm.isQuestStarted(32009)) {
                             cm.sendNext("Oh, isn't this a letter from the #bDark Lord#k?");
                         } else {
                             cm.sendOk("I can show you the way once your ready for it.");
@@ -65,8 +65,8 @@ function action(mode, type, selection) {
                     cm.sendAcceptDecline("I will give you a chance if you're ready.");
                 else if (status == 3) {
                     cm.sendOk("You will have to collect me #b30 #t4031013##k. Good luck.");
-                    cm.completeQuest(100009);
-                    cm.startQuest(100010);
+                    cm.completeQuest(32009);
+                    cm.startQuest(32010);
                     cm.gainItem(4031011, -1);
                 } else if (status == 4) {
                     cm.warp(108000400, 0);

--- a/scripts/npc/1072004.js
+++ b/scripts/npc/1072004.js
@@ -51,8 +51,8 @@ function action(mode, type, selection) {
                 } else if(status == 1) {
                     if(completed) {
                         cm.removeAll(4031013);
-                        cm.completeQuest(100004);
-                        cm.startQuest(100005);
+                        cm.completeQuest(32004);
+                        cm.startQuest(32005);
                         cm.gainItem(4031012);
                     }
                     

--- a/scripts/npc/1072005.js
+++ b/scripts/npc/1072005.js
@@ -51,8 +51,8 @@ function action(mode, type, selection) {
                 } else if(status == 1) {
                     if(completed) {
                         cm.removeAll(4031013);
-                        cm.completeQuest(100007);
-                        cm.startQuest(100008);
+                        cm.completeQuest(32007);
+                        cm.startQuest(32008);
                         cm.gainItem(4031012);
                     }
                     

--- a/scripts/npc/1072006.js
+++ b/scripts/npc/1072006.js
@@ -63,8 +63,8 @@ function action(mode, type, selection) {
                 } else if(status == 1) {
                     if(completed) {
                         cm.removeAll(4031013);
-                        cm.completeQuest(100001);
-                        cm.startQuest(100002);
+                        cm.completeQuest(32001);
+                        cm.startQuest(32002);
                         cm.gainItem(4031012);
                     }
                     

--- a/scripts/npc/1072007.js
+++ b/scripts/npc/1072007.js
@@ -62,8 +62,8 @@ function action(mode, type, selection) {
                 } else if(status == 1) {
                         if(completed) {
                             cm.removeAll(4031013);
-                            cm.completeQuest(100010);
-                            cm.startQuest(100011);
+                            cm.completeQuest(32010);
+                            cm.startQuest(32011);
                             cm.gainItem(4031012);
                         }
                         

--- a/src/main/java/client/MapleCharacter.java
+++ b/src/main/java/client/MapleCharacter.java
@@ -11162,7 +11162,7 @@ public class MapleCharacter extends AbstractMapleCharacterObject {
             return;
         }
 
-        // Reset all the quest ids so the people can do job advancements again.
+        // Reset all the quest ids so the player can do job advancements again.
         for (int id : GameConstants.JOB_ADV_QUEST_IDS) {
             forfeitQuest(id);
         }

--- a/src/main/java/client/MapleCharacter.java
+++ b/src/main/java/client/MapleCharacter.java
@@ -9811,7 +9811,14 @@ public class MapleCharacter extends AbstractMapleCharacterObject {
             }
         }
     }
-    
+
+    /**
+     * Updates the progress for a quest. For example, eating rogers apple would apply the infoNumber for rogers apple to 1.
+     *
+     * @param id Quest id to apply the update to.
+     * @param infoNumber ID of the thing that the quest is tracking.
+     * @param progress New progress value that the player has achieved.
+     */
     public void setQuestProgress(int id, int infoNumber, String progress) {
         MapleQuest q = MapleQuest.getInstance(id);
         MapleQuestStatus qs = getQuest(q);
@@ -9927,6 +9934,19 @@ public class MapleCharacter extends AbstractMapleCharacterObject {
             }
             // reminder: do not reset quest progress of infoNumbers, some quests cannot backtrack
         }
+    }
+
+    /**
+     * Adds a quest to be forfeited to the delayed quest update list, for processing when ready.
+     * This method can also be used to reset completed quests, but each quest in a series must be forfeit individually.
+     *
+     * @param id ID of the quest that should be forfeit.
+     */
+    public void forfeitQuest(int id) {
+        MapleQuest q = MapleQuest.getInstance(id);
+        MapleQuestStatus qs = getQuest(q);
+
+        announceUpdateQuest(DelayedQuestUpdate.FORFEIT, qs.getQuestID());
     }
     
     private void expireQuest(MapleQuest quest) {
@@ -11141,6 +11161,12 @@ public class MapleCharacter extends AbstractMapleCharacterObject {
         if (getLevel() != 200) {
             return;
         }
+
+        // Reset all the quest ids so the people can do job advancements again.
+        for (int id : GameConstants.JOB_ADV_QUEST_IDS) {
+            forfeitQuest(id);
+        }
+
         addReborns();
         changeJob(MapleJob.BEGINNER);
         setLevel(0);

--- a/src/main/java/constants/game/GameConstants.java
+++ b/src/main/java/constants/game/GameConstants.java
@@ -51,6 +51,151 @@ public class GameConstants {
     public static int getPlayerBonusExpRate(int slot) {
         return(EXP_RATE_GAIN[slot]);
     }
+
+    // All of the quest IDs for job advancements and training quests.
+    // May be an incomplete list as there are skill quests too somewhere.
+    public static short[] JOB_ADV_QUEST_IDS = new short[] {
+            // Explorer training session quests.
+            2128, // Beginner Warrior's First Training Session.
+            2129, // Beginner Warrior's Second Training Session.
+            2130, // Beginner Warrior's Third Training Session.
+            2131, // Beginner Warrior's Last Training Session.
+            2132, // Beginner Magician's First Training Session.
+            2133, // Beginner Magician's Second Training Session.
+            2134, // Beginner Magician's Third Training Session.
+            2135, // Beginner Magician's Last Training Session.
+            2136, // Beginner Bowman's First Training Session.
+            2137, // Beginner Bowman's Second Training Session.
+            2138, // Beginner Bowman's Third Training Session.
+            2139, // Beginner Bowman's Last Training Session.
+            2140, // Beginner Thief's First Training Session.
+            2141, // Beginner Thief's Second Training Session.
+            2142, // Beginner Thief's Third Training Session.
+            2143, // Beginner Thief's Last Training Session.
+            2191, // How to become a Brawler.
+            2192, // How to Become a Gunslinger.
+            2193, // The Beginner Pirate's First Training Session.
+            2194, // The Beginner Pirate's Second Training Session.
+            2195, // The Beginner Pirate's Third Training Session.
+            2196, // The Beginner Pirate's Fourth Training Session.
+
+            // Explorer advancement quests. Custom quest IDs. Pirate doesn't have these.
+            32000, // Bowman second job letter.
+            32001, // Bowman second job marbles.
+            32002, // Bowman second job proof of hero.
+            32003, // Warrior second job letter.
+            32004, // Warrior second job marbles.
+            32005, // Warrior second job proof of hero.
+            32006, // Magician second job letter.
+            32007, // Magician second job marbles.
+            32008, // Magician second job proof of hero.
+            32009, // Thief second job letter.
+            32010, // Thief second job marbles.
+            32011, // Thief second job proof of hero.
+
+            // Explorer 4th job.
+            6900, // Tylus' introduction letter. Warrior.
+            6901, // Harmonia's first story.
+            6902, // Harmonia's second truth.
+            6903, // Harmonia's third story.
+            6904, // Hero's Quality.
+            6905, // Tatamo's Suggestion.
+            6910, // Robeira's introduction letter. Magician.
+            6911, // Gritto's first story.
+            6912, // Gritto's Second Story.
+            6913, // Gritto's Third Story.
+            6914, // A Hero's Quality.
+            6915, // Tatamo's Suggestion.
+            6920, // Rene's Introduction Letter. Bowman.
+            6921, // Legor's First Story.
+            6922, // Legor's Second Truth.
+            6923, // Legor's Third Story.
+            6924, // Hero's Quality.
+            6925, // Tatamo's Suggestion.
+            6930, // Arec's Letter of Introduction. Thief.
+            6931, // Helin's First Story.
+            6932, // Helin's Second Truth.
+            6933, // Hellin's Third Story.
+            6934, // Hero's Quality.
+            6935, // Tatamo's Suggestion.
+            6940, // Pedro's Introduction. Pirate.
+            6941, // Samuel's Revelation of the First Truth.
+            6942, // Samuel's Revelation of the Second Truth.
+            6943, // Samuel's Revelation of the Third Truth.
+            6944, // Attributes of a Hero.
+            6945, // Tatamo's Suggestion.
+
+            // Cygnus advancement quests.
+            20101, // Dawn warrior first job.
+            20102, // Blaze wizard first job.
+            20103, // Wind archer first job.
+            20104, // Night Walker first job.
+            20105, // Thunder Breaker first job.
+            20201, // Dawn warrior second job.
+            20202, // Blaze wizard second job.
+            20203, // Wind archer second job.
+            20204, // Night Walker second job.
+            20205, // Thunder Breaker second job.
+
+            // Cygnus third job.
+            20300, // The Lost Treasure.
+            20301, // The Master of Disguise - Dawn warrior.
+            20302, // The Master of Disguise - Blaze wizard.
+            20303, // The Master of Disguise - Wind archer.
+            20304, // The Master of Disguise - Night walker.
+            20305, // The Master of Disguise - Thunder breaker.
+            20306, // Ereve Investigation Permit - Dawn warrior.
+            20307, // Ereve Investigation Permit - Blaze wizard.
+            20308, // Ereve Investigation Permit - Wind archer.
+            20309, // Ereve Investigation Permit - Night walker.
+            20310, // Ereve Investigation Permit - Thunder breaker.
+            20311, // Shinsoo's Teardrop - Dawn warrior.
+            20312, // Shinsoo's Teardrop - Blaze wizard.
+            20313, // Shinsoo's Teardrop - Wind archer.
+            20314, // Shinsoo's Teardrop - Night walker.
+            20315, // Shinsoo's Teardrop - Thunder breaker.
+
+            // Cygnus skills.
+            20601, // Dawn warrior first new skill.
+            20602, // Blaze wizard first new skill.
+            20603, // Wind archer first new skill.
+            20604, // Night Walker first new skill.
+            20605, // Thunder Breaker first new skill.
+            20611, // Dawn warrior second new skill.
+            20612, // Blaze wizard second new skill.
+            20613, // Wind archer second new skill.
+            20614, // Night Walker second new skill.
+            20615, // Thunder Breaker second new skill.
+
+            // Aran quests.
+            10341, // Aran's revival.
+            10342, // Vague Aran Memories.
+            10344, // Dim Aran Memories.
+            10345, // Signs of the Revival.
+            10346, // Faint Aran Memories.
+            10347, // The Wolf In Waiting.
+            10348, // Cloudy Aran Memories.
+            10349, // Preparing for the Arrival.
+            10350, // Lingering Aran Memories.
+            10351, // The Hero's Memory.
+            10352, // Flickering Aran Memories.
+            10353, // The Truth About Memory Fragments.
+            10360, // Aran Welcome Celebration.
+            10370, // Find the Master of Combos.
+            10380, // Aran's Return.
+            21010, // The Return of the Hero.
+            21011, // The Missing Weapon.
+            21012, // Abilities Lost.
+            21013, // A Gift for the Hero.
+            21014, // Lilin's Account.
+            21015, // Basic Fitness Training 1.
+            21016, // Basic Fitness Training 2.
+            21017, // Basic Fitness Training 3.
+            21018, // Basic Fitness Test.
+            10381, // Lilin's Present 3.
+            28335, // Lilin's Present 1.
+            28336, // Lilin's Present 2.
+    };
     
     // "goto" command for players
     public static final HashMap<String, Integer> GOTO_TOWNS = new HashMap<String, Integer>() {{


### PR DESCRIPTION
Fixes #34 

Clears the job quests that are required in order to progress again on rebirth, updated the custom explorer second job quest ids to be within `short` range, added in the missing bowman final 2nd job custom quest completion.

Still an incomplete list, I need to find out which other quests and skill quests need to be reset in order for this to work properly.