### PR TITLE
Fix issue with packet bytes reuse

### DIFF
--- a/src/main/java/net/packet/ByteBufOutPacket.java
+++ b/src/main/java/net/packet/ByteBufOutPacket.java
@@ -12,7 +12,6 @@ import java.awt.*;
 @NotThreadSafe
 public class ByteBufOutPacket implements OutPacket {
     private final ByteBuf byteBuf;
-    private byte[] bytes;
 
     public ByteBufOutPacket() {
         this.byteBuf = Unpooled.buffer();
@@ -32,12 +31,7 @@ public class ByteBufOutPacket implements OutPacket {
 
     @Override
     public byte[] getBytes() {
-        if (bytes == null) {
-            // Avoid creating new byte arrays when the packet is broadcast
-            bytes = ByteBufUtil.getBytes(byteBuf);
-        }
-
-        return bytes;
+        return ByteBufUtil.getBytes(byteBuf);
     }
 
     @Override

--- a/src/test/java/net/packet/ByteBufOutPacketTest.java
+++ b/src/test/java/net/packet/ByteBufOutPacketTest.java
@@ -203,15 +203,4 @@ class ByteBufOutPacketTest {
         assertEquals(0, wrapped.readByte());
         assertEquals(secondWrittenByte, wrapped.readByte());
     }
-
-    @Test
-    void whenGettingBytesRepeatedly_bytesShouldBeLockedInPlace() {
-        outPacket.writeByte(1);
-        byte[] initialWrite = outPacket.getBytes();
-
-        outPacket.writeByte(2);
-        byte[] afterWritingAgain = outPacket.getBytes();
-
-        assertArrayEquals(initialWrite, afterWritingAgain);
-    }
 }


### PR DESCRIPTION
Big oversight that caused broadcasted (packet sent to multiple clients)
packets to only be correct for the first receiver, for example when
3 players were in the same map.