### PR TITLE
Bump log4j to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <mainClass>net.server.Server</mainClass>
 
-        <log4j.version>2.14.1</log4j.version>
+        <log4j.version>2.15.0</log4j.version>
         <graalvm.version>21.1.0</graalvm.version>
         <netty.version>4.1.67.Final</netty.version>
         <junit.version>5.7.2</junit.version>

--- a/src/main/java/net/server/Server.java
+++ b/src/main/java/net/server/Server.java
@@ -844,6 +844,7 @@ public class Server {
         futures.add(initExecutor.submit(() -> Quest.loadAllQuests()));
         futures.add(initExecutor.submit(() -> SkillbookInformationProvider.loadAllSkillbookInformation()));
         futures.add(initExecutor.submit(() -> PlayerNPCFactory.loadFactoryMetadata()));
+        initExecutor.shutdown();
 
         TimeZone.setDefault(TimeZone.getTimeZone(YamlConfig.config.server.TIMEZONE));
 


### PR DESCRIPTION
2.14.1 and earlier (famously) contains a RCE exploit.