### PR TITLE
Update rebirth NPC to allow path selection

### DIFF
--- a/scripts/npc/rebirth.js
+++ b/scripts/npc/rebirth.js
@@ -50,10 +50,10 @@ function action(mode, type, selection) {
         cm.sendSimple("What do you want me to do today: \r\n \r\n #L0##bI want to be reborn!#l \r\n #L1##bNothing for now...#k#l");
     } else if (status === 2) {
         if (selection === 0) {
-            if (cm.getChar().getLevel() === 200) {
+            if (cm.getChar().getLevel() === cm.getChar().getMaxClassLevel()) {
                 cm.sendSimple("I see... and which path would you like to take? \r\n\r\n #L0##bExplorer (Beginner)#l \r\n #L1##bCygnus Knight (Noblesse)#l \r\n #L2##bAran (Legend)#l");
             } else {
-                cm.sendOk("You are not level 200, please come back when you hit level 200.");
+                cm.sendOk("It looks like your journey has not yet ended... come back when you're level " + cm.getChar().getMaxClassLevel());
                 cm.dispose();
             }
         } else if (selection === 1) {
@@ -64,7 +64,7 @@ function action(mode, type, selection) {
         // 0 => beginner, 1000 => noblesse, 2000 => legend
         // makes this very easy :-)
         jobId = selection * 1000;
-        
+
         var job = "";
         if (selection === 0) job = "Beginner";
         else if (selection === 1) job = "Noblesse";

--- a/scripts/npc/rebirth.js
+++ b/scripts/npc/rebirth.js
@@ -24,6 +24,7 @@
     @author wejrox
 */
 var status;
+var jobId = 0;
 
 function start() {
     status = -1;
@@ -50,7 +51,7 @@ function action(mode, type, selection) {
     } else if (status === 2) {
         if (selection === 0) {
             if (cm.getChar().getLevel() === 200) {
-                cm.sendYesNo("Are you sure you want to be reborn?");
+                cm.sendSimple("I see... and which path would you like to take? \r\n\r\n #L0##bExplorer (Beginner)#l \r\n #L1##bCygnus Knight (Noblesse)#l \r\n #L2##bAran (Legend)#l");
             } else {
                 cm.sendOk("You are not level 200, please come back when you hit level 200.");
                 cm.dispose();
@@ -59,8 +60,19 @@ function action(mode, type, selection) {
             cm.sendOk("See you soon!")
             cm.dispose();
         }
-    } else if (status === 3 && type === 1) {
-        cm.getChar().executeReborn();
+    } else if (status === 3) {
+        // 0 => beginner, 1000 => noblesse, 2000 => legend
+        // makes this very easy :-)
+        jobId = selection * 1000;
+        
+        var job = "";
+        if (selection === 0) job = "Beginner";
+        else if (selection === 1) job = "Noblesse";
+        else if (selection === 2) job = "Legend";
+        cm.sendYesNo("Are you sure you want to be reborn as a " + job + "?");
+    }
+    else if (status === 4 && type === 1) {
+        cm.getChar().executeRebornAsId(jobId);
         cm.sendOk("You have now been reborn. That's a total of #r" + cm.getChar().getReborns() + "#k rebirths");
         cm.dispose();
     }

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -11151,7 +11151,7 @@ public class Character extends AbstractCharacterObject {
             yellowMessage("Rebirth system is not enabled!");
             throw new NotEnabledException();
         }
-        if (getLevel() != 200) {
+        if (getLevel() != getMaxClassLevel()) {
             return;
         }
         addReborns();

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -11137,6 +11137,16 @@ public class Character extends AbstractCharacterObject {
     }
 
     public void executeReborn() {
+        // default to beginner: job id = 0
+        // this prevents a breaking change
+        executeRebornAs(Job.BEGINNER);
+    }
+
+    public void executeRebornAsId(int jobId) {
+        executeRebornAs(Job.getById(jobId));
+    }
+
+    public void executeRebornAs(Job job) {
         if (!YamlConfig.config.server.USE_REBIRTH_SYSTEM) {
             yellowMessage("Rebirth system is not enabled!");
             throw new NotEnabledException();
@@ -11145,7 +11155,7 @@ public class Character extends AbstractCharacterObject {
             return;
         }
         addReborns();
-        changeJob(Job.BEGINNER);
+        changeJob(job);
         setLevel(0);
         levelUp(true);
     }


### PR DESCRIPTION
Resolves #37  and also fixes a bug where if you were e.g. a maxed level 120 KoC character, you couldn't rebirth (replaced level = 200 check with level = getMaxClassLevel())

Updated NPC menu for path selection

![image](https://user-images.githubusercontent.com/52503242/184811539-8fc1e19b-3c52-4eb3-b62c-daaaccd25125.png)

![image](https://user-images.githubusercontent.com/52503242/184811570-80ecbf17-601b-4914-8ab5-98597ad2567d.png)

Updated NPC text for job level check

![image](https://user-images.githubusercontent.com/52503242/184811461-7802a9ee-92e6-46fa-9f01-235916bd1243.png)
