### PR TITLE
Allow pet cash food to increase closeness even when pet fullness is maxed

### DIFF
--- a/src/main/java/client/inventory/Pet.java
+++ b/src/main/java/client/inventory/Pet.java
@@ -185,11 +185,16 @@ public class Pet extends Item {
     }
 
     public void gainClosenessFullness(Character owner, int incTameness, int incFullness, int type) {
+        gainClosenessFullness(owner, incTameness, incFullness, type, false);
+    }
+
+    public void gainClosenessFullness(Character owner, int incTameness, int incFullness, int type, boolean forceEnjoy) {
         byte slot = owner.getPetIndex(this);
         boolean enjoyed;
 
         //will NOT increase pet's closeness if tried to feed pet with 100% fullness
-        if (fullness < 100 || incFullness == 0) {   //incFullness == 0: command given
+        // unless forceEnjoy == true (cash shop)
+        if (fullness < 100 || incFullness == 0 || forceEnjoy) {   //incFullness == 0: command given
             int newFullness = fullness + incFullness;
             if (newFullness > 100) {
                 newFullness = 100;

--- a/src/main/java/net/server/channel/handlers/UseCashItemHandler.java
+++ b/src/main/java/net/server/channel/handlers/UseCashItemHandler.java
@@ -419,7 +419,7 @@ public final class UseCashItemHandler extends AbstractPacketHandler {
                     Pair<Integer, Boolean> pair = pet.canConsume(itemId);
 
                     if (pair.getRight()) {
-                        pet.gainClosenessFullness(player, pair.getLeft(), 100, 1);
+                        pet.gainClosenessFullness(player, pair.getLeft(), 100, 1, true);
                         remove(c, position, itemId);
                         break;
                     }


### PR DESCRIPTION
Resolves #103 

Adds a boolean forceEnjoy parameter to the Pet.gainClosenessFullness() method, as well as an overload to keep default functionality and prevent a breaking change.

(PS - you guys really have made PS development so easy to get going.  It's so much easier than when I tried to do this stuff 10 years ago.  Thank you for that!!)