### PR TITLE
Add missing skill constants

### DIFF
--- a/src/main/java/constants/skills/Aran.java
+++ b/src/main/java/constants/skills/Aran.java
@@ -25,30 +25,38 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Aran {
-    public static final int DOUBLE_SWING = 21000002;
-    public static final int TRIPLE_SWING = 21100001;
+    // 1st job
     public static final int COMBO_ABILITY = 21000000;
+    public static final int DOUBLE_SWING = 21000002;
     public static final int COMBAT_STEP = 21001001;
     public static final int POLEARM_BOOSTER = 21001003;
-    public static final int MAPLE_WARRIOR = 21121000;
-    public static final int FREEZE_STANDING = 21121003;
-    public static final int SNOW_CHARGE = 21111005;
-    public static final int HEROS_WILL = 21121008;
-    public static final int HIGH_DEFENSE = 21120004;
-    public static final int BODY_PRESSURE = 21101003;
+    // 2nd job
+    public static final int POLEARM_MASTERY = 21100000;
+    public static final int TRIPLE_SWING = 21100001;
+    public static final int FINAL_CHARGE = 21100002;
     public static final int COMBO_DRAIN = 21100005;
     public static final int COMBO_SMASH = 21100004;
-    public static final int COMBO_FENRIR = 21110004;
-    public static final int COMBO_CRITICAL = 21110000;
+    public static final int BODY_PRESSURE = 21101003;
+    // 3rd job
     public static final int FULL_SWING = 21110002;
+    public static final int COMBO_CRITICAL = 21110000;
+    public static final int FINAL_TOSS = 21110003; // Final Toss seems to be missing from the handbook, sourced ID elsewhere
+    public static final int COMBO_FENRIR = 21110004;
+    public static final int SNOW_CHARGE = 21111005;
+    public static final int SMART_KNOCKBACK = 21111001;
     public static final int ROLLING_SPIN = 21110006;
     public static final int HIDDEN_FULL_DOUBLE = 21110007;
     public static final int HIDDEN_FULL_TRIPLE = 21110008;
-    public static final int SMART_KNOCKBACK = 21111001;
+    // 4th job
+    public static final int MAPLE_WARRIOR = 21121000;
+    public static final int HIGH_MASTERY = 21120001;
     public static final int OVER_SWING = 21120002;
+    public static final int HIGH_DEFENSE = 21120004;
+    public static final int FINAL_BLOW = 21120005;
     public static final int COMBO_TEMPEST = 21120006;
     public static final int COMBO_BARRIER = 21120007;
+    public static final int FREEZE_STANDING = 21121003;
+    public static final int HEROS_WILL = 21121008;
     public static final int HIDDEN_OVER_DOUBLE = 21120009;
     public static final int HIDDEN_OVER_TRIPLE = 21120010;
-    public static final int HIGH_MASTERY = 21120001;
 }

--- a/src/main/java/constants/skills/Archer.java
+++ b/src/main/java/constants/skills/Archer.java
@@ -25,6 +25,10 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Archer {
+    public static final int BLESSING_OF_AMAZON = 3000000;
+    public static final int EYE_OF_AMAZON = 3000002;
     public static final int CRITICAL_SHOT = 3000001;
     public static final int FOCUS = 3001003;
+    public static final int DOUBLE_SHOT = 3001005;
+    public static final int ARROW_BLOW = 3001004;
 }

--- a/src/main/java/constants/skills/Bishop.java
+++ b/src/main/java/constants/skills/Bishop.java
@@ -32,6 +32,7 @@ public class Bishop {
     public static final int INFINITY = 2321004;
     public static final int HOLY_SHIELD = 2321005;
     public static final int RESURRECTION = 2321006;
+    public static final int ANGEL_RAY = 2321007;
     public static final int GENESIS = 2321008;
     public static final int HEROS_WILL = 2321009;
 }

--- a/src/main/java/constants/skills/BlazeWizard.java
+++ b/src/main/java/constants/skills/BlazeWizard.java
@@ -25,18 +25,26 @@ package constants.skills;
  * @author BubblesDev
  */
 public class BlazeWizard {
-    public static final int ELEMENTAL_RESET = 12101005;
-    public static final int ELEMENT_AMPLIFICATION = 12110001;
-    public static final int FIRE_STRIKE = 12111006;
-    public static final int FLAME = 12001004;
-    public static final int FLAME_GEAR = 12111005;
-    public static final int IFRIT = 12111004;
+    // 1st job
     public static final int INCREASING_MAX_MP = 12000000;
-    public static final int MAGIC_ARMOR = 12001002;
     public static final int MAGIC_GUARD = 12001001;
+    public static final int MAGIC_ARMOR = 12001002;
+    public static final int MAGIC_CLAW = 12001003;
+    public static final int FLAME = 12001004;
+    // 2nd job
     public static final int MEDITATION = 12101000;
-    public static final int SEAL = 12111002;
     public static final int SLOW = 12101001;
+    public static final int FIRE_ARROW = 12101002;
+    public static final int TELEPORT = 12101003;
     public static final int SPELL_BOOSTER = 12101004;
+    public static final int ELEMENTAL_RESET = 12101005;
     public static final int FIRE_PILLAR = 12101006;
+    // 3rd job
+    public static final int ELEMENTAL_RESISTANCE = 12110000;
+    public static final int ELEMENT_AMPLIFICATION = 12110001;
+    public static final int SEAL = 12111002;
+    public static final int METEOR_SHOWER = 12111003;
+    public static final int IFRIT = 12111004;
+    public static final int FLAME_GEAR = 12111005;
+    public static final int FIRE_STRIKE = 12111006;
 }

--- a/src/main/java/constants/skills/Bowmaster.java
+++ b/src/main/java/constants/skills/Bowmaster.java
@@ -26,7 +26,9 @@ package constants.skills;
  */
 public class Bowmaster {
     public static final int MAPLE_WARRIOR = 3121000;
+    public static final int VENGEANCE = 3121001;
     public static final int SHARP_EYES = 3121002;
+    public static final int DRAGONS_BREATH = 3121003;
     public static final int HURRICANE = 3121004;
     public static final int BOW_EXPERT = 3120005;
     public static final int PHOENIX = 3121006;

--- a/src/main/java/constants/skills/Bowmaster.java
+++ b/src/main/java/constants/skills/Bowmaster.java
@@ -26,7 +26,6 @@ package constants.skills;
  */
 public class Bowmaster {
     public static final int MAPLE_WARRIOR = 3121000;
-    public static final int VENGEANCE = 3121001;
     public static final int SHARP_EYES = 3121002;
     public static final int DRAGONS_BREATH = 3121003;
     public static final int HURRICANE = 3121004;

--- a/src/main/java/constants/skills/ChiefBandit.java
+++ b/src/main/java/constants/skills/ChiefBandit.java
@@ -25,6 +25,7 @@ package constants.skills;
  * @author BubblesDev
  */
 public class ChiefBandit {
+    public static final int SHIELD_MASTERY = 4210000;
     public static final int CHAKRA = 4211001;
     public static final int ASSAULTER = 4211002;
     public static final int PICKPOCKET = 4211003;

--- a/src/main/java/constants/skills/Cleric.java
+++ b/src/main/java/constants/skills/Cleric.java
@@ -25,5 +25,7 @@ public class Cleric {
     public static final int MP_EATER = 2300000;
     public static final int HEAL = 2301002;
     public static final int INVINCIBLE = 2301003;
+    public static final int TELEPORT = 2301001;
     public static final int BLESS = 2301004;
+    public static final int HOLY_ARROW = 2301005;
 }

--- a/src/main/java/constants/skills/Corsair.java
+++ b/src/main/java/constants/skills/Corsair.java
@@ -31,6 +31,8 @@ public class Corsair {
     public static final int AERIAL_STRIKE = 5221003;
     public static final int RAPID_FIRE = 5221004;
     public static final int BATTLE_SHIP = 5221006;
+    public static final int BATTLESHIP_CANNON = 5221007;
+    public static final int BATTLESHIP_TORPEDO = 5221008;
     public static final int HYPNOTIZE = 5221009;
     public static final int SPEED_INFUSION = 5221010;
     public static final int BULLSEYE = 5220011;

--- a/src/main/java/constants/skills/Crossbowman.java
+++ b/src/main/java/constants/skills/Crossbowman.java
@@ -28,5 +28,7 @@ public class Crossbowman {
     public static final int CROSSBOW_MASTERY = 3200000;
     public static final int FINAL_ATTACK = 3200001;
     public static final int CROSSBOW_BOOSTER = 3201002;
+    public static final int POWER_KNOCKBACK = 3201003;
     public static final int SOUL_ARROW = 3201004;
+    public static final int IRON_ARROW = 3201005;
 }

--- a/src/main/java/constants/skills/Crusader.java
+++ b/src/main/java/constants/skills/Crusader.java
@@ -25,6 +25,8 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Crusader {
+    public static final int IMPROVING_MPREC = 1110000;
+    public static final int SHIELD_MASTERY = 1111001;
     public static final int COMBO = 1111002;
     public static final int SWORD_PANIC = 1111003;
     public static final int AXE_PANIC = 1111004;

--- a/src/main/java/constants/skills/Crusader.java
+++ b/src/main/java/constants/skills/Crusader.java
@@ -26,7 +26,7 @@ package constants.skills;
  */
 public class Crusader {
     public static final int IMPROVING_MPREC = 1110000;
-    public static final int SHIELD_MASTERY = 1111001;
+    public static final int SHIELD_MASTERY = 1110001;
     public static final int COMBO = 1111002;
     public static final int SWORD_PANIC = 1111003;
     public static final int AXE_PANIC = 1111004;

--- a/src/main/java/constants/skills/DawnWarrior.java
+++ b/src/main/java/constants/skills/DawnWarrior.java
@@ -25,17 +25,26 @@ package constants.skills;
  * @author BubblesDev
  */
 public class DawnWarrior {
+    // 1st job
     public static final int MAX_HP_INCREASE = 11000000;
     public static final int IRON_BODY = 11001001;
+    public static final int POWER_STRIKE = 11001002;
+    public static final int SLASH_BLAST = 11001003;
     public static final int SOUL = 11001004;
+    // 2nd job
     public static final int SWORD_MASTERY = 11100000;
     public static final int SWORD_BOOSTER = 11101001;
     public static final int FINAL_ATTACK = 11101002;
     public static final int RAGE = 11101003;
+    public static final int SOUL_BLADE = 11101004;
+    public static final int SOUL_RUSH = 11101005;
+    // 3rd job
     public static final int INCREASED_MP_RECOVERY = 11110000;
     public static final int COMBO = 11111001;
     public static final int PANIC = 11111002;
     public static final int COMA = 11111003;
+    public static final int BRANDISH = 11111004;
     public static final int ADVANCED_COMBO = 11110005;
+    public static final int SOUL_DRIVER = 11111006;
     public static final int SOUL_CHARGE = 11111007;
 }

--- a/src/main/java/constants/skills/DragonKnight.java
+++ b/src/main/java/constants/skills/DragonKnight.java
@@ -28,6 +28,8 @@ public class DragonKnight {
     public static final int ELEMENTAL_RESISTANCE = 1310000;
     public static final int SPEAR_CRUSHER = 1311001;
     public static final int POLE_ARM_CRUSHER = 1311002;
+    public static final int SPEAR_DRAGON_FURY = 1311003;
+    public static final int POLE_ARM_DRAGON_FURY = 1311004;
     public static final int SACRIFICE = 1311005;
     public static final int DRAGON_ROAR = 1311006;
     public static final int POWER_CRASH = 1311007;

--- a/src/main/java/constants/skills/FPWizard.java
+++ b/src/main/java/constants/skills/FPWizard.java
@@ -27,6 +27,7 @@ package constants.skills;
 public class FPWizard {
     public static final int MP_EATER = 2100000;
     public static final int MEDITATION = 2101001;
+    public static final int TELEPORT = 2101002;
     public static final int SLOW = 2101003;
     public static final int FIRE_ARROW = 2101004;
     public static final int POISON_BREATH = 2101005;

--- a/src/main/java/constants/skills/Gunslinger.java
+++ b/src/main/java/constants/skills/Gunslinger.java
@@ -30,5 +30,6 @@ public class Gunslinger {
     public static final int GRENADE = 5201002;
     public static final int GUN_BOOSTER = 5201003;
     public static final int BLANK_SHOT = 5201004;
+    public static final int WINGS = 5201005;
     public static final int RECOIL_SHOT = 5201006;
 }

--- a/src/main/java/constants/skills/Hunter.java
+++ b/src/main/java/constants/skills/Hunter.java
@@ -28,6 +28,7 @@ public class Hunter {
     public static final int BOW_MASTERY = 3100000;
     public static final int FINAL_ATTACK = 3100001;
     public static final int BOW_BOOSTER = 3101002;
+    public static final int POWER_KNOCKBACK = 3101003;
     public static final int SOUL_ARROW = 3101004;
     public static final int ARROW_BOMB = 3101005;
 }

--- a/src/main/java/constants/skills/ILMage.java
+++ b/src/main/java/constants/skills/ILMage.java
@@ -28,6 +28,7 @@ public class ILMage {
     public static final int PARTIAL_RESISTANCE = 2210000;
     public static final int ELEMENT_AMPLIFICATION = 2210001;
     public static final int ICE_STRIKE = 2211002;
+    public static final int THUNDER_SPEAR = 2211003;
     public static final int SEAL = 2211004;
     public static final int SPELL_BOOSTER = 2211005;
     public static final int ELEMENT_COMPOSITION = 2211006;

--- a/src/main/java/constants/skills/ILWizard.java
+++ b/src/main/java/constants/skills/ILWizard.java
@@ -27,6 +27,8 @@ package constants.skills;
 public class ILWizard {
     public static final int MP_EATER = 2200000;
     public static final int MEDITATION = 2201001;
+    public static final int TELEPORT = 2201002;
     public static final int SLOW = 2201003;
     public static final int COLD_BEAM = 2201004;
+    public static final int THUNDERBOLT = 2201005;
 }

--- a/src/main/java/constants/skills/Magician.java
+++ b/src/main/java/constants/skills/Magician.java
@@ -29,4 +29,6 @@ public class Magician {
     public static final int IMPROVED_MAX_MP_INCREASE = 2000001;
     public static final int MAGIC_GUARD = 2001002;
     public static final int MAGIC_ARMOR = 2001003;
+    public static final int ENERGY_BOLT = 2001004;
+    public static final int MAGIC_CLAW = 2001005;
 }

--- a/src/main/java/constants/skills/Marauder.java
+++ b/src/main/java/constants/skills/Marauder.java
@@ -27,6 +27,8 @@ package constants.skills;
 public class Marauder {
     public static final int STUN_MASTERY = 5110000;
     public static final int ENERGY_CHARGE = 5110001;
+    public static final int ENERGY_BLAST = 5111002;
     public static final int ENERGY_DRAIN = 5111004;
     public static final int TRANSFORMATION = 5111005;
+    public static final int SHOCKWAVE = 5111006;
 }

--- a/src/main/java/constants/skills/Marksman.java
+++ b/src/main/java/constants/skills/Marksman.java
@@ -28,6 +28,7 @@ public class Marksman {
     public static final int MAPLE_WARRIOR = 3221000;
     public static final int PIERCING_ARROW = 3221001;
     public static final int SHARP_EYES = 3221002;
+    public static final int DRAGONS_BREATH = 3221003;
     public static final int MARKSMAN_BOOST = 3220004;
     public static final int FROST_PREY = 3221005;
     public static final int BLIND = 3221006;

--- a/src/main/java/constants/skills/NightWalker.java
+++ b/src/main/java/constants/skills/NightWalker.java
@@ -25,20 +25,27 @@ package constants.skills;
  * @author BubblesDev
  */
 public class NightWalker {
-    public static final int ALCHEMIST = 14110003;
-    public static final int DISORDER = 14001002;
+    // 1st job
+    public static final int NIMBLE_BODY = 14000000;
+    public static final int KEEN_EYES = 14000001;
+    public static final int DISORDER = 14000002;
     public static final int DARK_SIGHT = 14001003;
     public static final int LUCKY_SEVEN = 14001004;
     public static final int DARKNESS = 14001005;
-    public static final int CLAW_BOOSTER = 14101002;
+    // 2nd job
     public static final int CLAW_MASTERY = 14100000;
     public static final int CRITICAL_THROW = 14100001;
+    public static final int CLAW_BOOSTER = 14101002;
     public static final int HASTE = 14101003;
-    public static final int POISON_BOMB = 14111006;
+    public static final int FLASH_JUMP = 14101004;
+    public static final int VANISH = 14100005;
+    public static final int VAMPIRE = 14101006;
+    // 3rd job
     public static final int SHADOW_PARTNER = 14111000;
     public static final int SHADOW_WEB = 14111001;
-    public static final int VANISH = 14100005;
-    public static final int FLASH_JUMP = 14101004;
-    public static final int VAMPIRE = 14101006;
+    public static final int AVENGER = 14111002;
+    public static final int ALCHEMIST = 14110003;
     public static final int VENOM = 14110004;
+    public static final int TRIPLE_THROW = 14110005;
+    public static final int POISON_BOMB = 14111006;
 }

--- a/src/main/java/constants/skills/Outlaw.java
+++ b/src/main/java/constants/skills/Outlaw.java
@@ -25,6 +25,7 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Outlaw {
+    public static final int BURST_FIRE = 5210000;
     public static final int OCTOPUS = 5211001;
     public static final int GAVIOTA = 5211002;
     public static final int FLAME_THROWER = 5211004;

--- a/src/main/java/constants/skills/Pirate.java
+++ b/src/main/java/constants/skills/Pirate.java
@@ -25,5 +25,9 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Pirate {
+    public static final int BULLET_TIME = 5000000;
+    public static final int FLASH_FIST = 5001001;
+    public static final int SOMERSAULT_KICK = 5001002;
+    public static final int DOUBLE_SHOT = 5001003;
     public static final int DASH = 5001005;
 }

--- a/src/main/java/constants/skills/Priest.java
+++ b/src/main/java/constants/skills/Priest.java
@@ -29,6 +29,7 @@ public class Priest {
     public static final int DISPEL = 2311001;
     public static final int MYSTIC_DOOR = 2311002;
     public static final int HOLY_SYMBOL = 2311003;
+    public static final int SHINING_RAY = 2311004;
     public static final int DOOM = 2311005;
     public static final int SUMMON_DRAGON = 2311006;
 }

--- a/src/main/java/constants/skills/Ranger.java
+++ b/src/main/java/constants/skills/Ranger.java
@@ -25,7 +25,11 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Ranger {
+    public static final int THRUST = 3110000;
     public static final int MORTAL_BLOW = 3110001;
     public static final int PUPPET = 3111002;
+    public static final int INFERNO = 3111003;
+    public static final int ARROW_RAIN = 3111004;
     public static final int SILVER_HAWK = 3111005;
+    public static final int STRAFE = 3111006;
 }

--- a/src/main/java/constants/skills/Rogue.java
+++ b/src/main/java/constants/skills/Rogue.java
@@ -26,6 +26,7 @@ package constants.skills;
  */
 public class Rogue {
     public static final int NIMBLE_BODY = 4001000;
+    public static final int KEEN_EYES = 4001001;
     public static final int DARK_SIGHT = 4001003;
     public static final int DISORDER = 4001002;
     public static final int DOUBLE_STAB = 4001334;

--- a/src/main/java/constants/skills/Sniper.java
+++ b/src/main/java/constants/skills/Sniper.java
@@ -25,8 +25,11 @@ package constants.skills;
  * @author BubblesDev
  */
 public class Sniper {
+    public static final int THRUST = 3210000;
     public static final int MORTAL_BLOW = 3210001;
     public static final int PUPPET = 3211002;
     public static final int BLIZZARD = 3211003;
+    public static final int ARROW_ERUPTION = 3210004;
     public static final int GOLDEN_EAGLE = 3211005;
+    public static final int STRAFE = 3210006;
 }

--- a/src/main/java/constants/skills/Sniper.java
+++ b/src/main/java/constants/skills/Sniper.java
@@ -29,7 +29,7 @@ public class Sniper {
     public static final int MORTAL_BLOW = 3210001;
     public static final int PUPPET = 3211002;
     public static final int BLIZZARD = 3211003;
-    public static final int ARROW_ERUPTION = 3210004;
+    public static final int ARROW_ERUPTION = 3211004;
     public static final int GOLDEN_EAGLE = 3211005;
-    public static final int STRAFE = 3210006;
+    public static final int STRAFE = 3211006;
 }

--- a/src/main/java/constants/skills/ThunderBreaker.java
+++ b/src/main/java/constants/skills/ThunderBreaker.java
@@ -25,18 +25,27 @@ package constants.skills;
  * @author BubblesDev
  */
 public class ThunderBreaker {
+    // 1st job
+    public static final int QUICK_MOTION = 15000000;
+    public static final int FIRST_STRIKE = 15001001;
+    public static final int SOMERSAULT_KICK = 15001002;
     public static final int DASH = 15001003;
+    public static final int LIGHTNING = 15001004;
+    // 2nd job
     public static final int IMPROVE_MAX_HP = 15100000;
     public static final int KNUCKLER_MASTERY = 15100001;
-    public static final int ENERGY_CHARGE = 15100004;
     public static final int KNUCKLER_BOOSTER = 15101002;
     public static final int CORKSCREW_BLOW = 15101003;
-    public static final int LIGHTNING = 15001004;
+    public static final int ENERGY_CHARGE = 15100004;
+    public static final int ENERGY_BLAST = 15101005;
     public static final int LIGHTNING_CHARGE = 15101006;
-    public static final int ENERGY_DRAIN = 15111001;
+    // 3rd job
+    public static final int CRITICAL_PUNCH = 15110000;
     public static final int TRANSFORMATION = 15111002;
+    public static final int BARRAGE = 15111004;
     public static final int SPEED_INFUSION = 15111005;
+    public static final int SHOCK_WAVE = 15111003;
+    public static final int ENERGY_DRAIN = 15111001;
     public static final int SPARK = 15111006;
     public static final int SHARK_WAVE = 15111007;
-    public static final int BARRAGE = 15111004;
 }

--- a/src/main/java/constants/skills/Warrior.java
+++ b/src/main/java/constants/skills/Warrior.java
@@ -10,5 +10,8 @@ package constants.skills;
 public class Warrior {
     public static final int IMPROVED_HPREC = 1000000;
     public static final int IMPROVED_MAXHP = 1000001;
+    public static final int ENDURE = 1000002;
     public static final int IRON_BODY = 1000003;
+    public static final int POWER_STRIKE = 1000004;
+    public static final int SLASH_BLAST = 1000005;
 }

--- a/src/main/java/constants/skills/WhiteKnight.java
+++ b/src/main/java/constants/skills/WhiteKnight.java
@@ -26,6 +26,7 @@ package constants.skills;
  */
 public class WhiteKnight {
     public static final int IMPROVING_MP_RECOVERY = 1210000;
+    public static final int SHIELD_MASTERY = 1211001;
     public static final int CHARGE_BLOW = 1211002;
     public static final int SWORD_FIRE_CHARGE = 1211003;
     public static final int BW_FIRE_CHARGE = 1211004;

--- a/src/main/java/constants/skills/WhiteKnight.java
+++ b/src/main/java/constants/skills/WhiteKnight.java
@@ -26,7 +26,7 @@ package constants.skills;
  */
 public class WhiteKnight {
     public static final int IMPROVING_MP_RECOVERY = 1210000;
-    public static final int SHIELD_MASTERY = 1211001;
+    public static final int SHIELD_MASTERY = 1210001;
     public static final int CHARGE_BLOW = 1211002;
     public static final int SWORD_FIRE_CHARGE = 1211003;
     public static final int BW_FIRE_CHARGE = 1211004;

--- a/src/main/java/constants/skills/WindArcher.java
+++ b/src/main/java/constants/skills/WindArcher.java
@@ -25,18 +25,27 @@ package constants.skills;
  * @author BubblesDev
  */
 public class WindArcher {
+    // 1st job
     public static final int CRITICAL_SHOT = 13000000;
+    public static final int EYE_OF_AMAZON = 13000001;
     public static final int FOCUS = 13001002;
+    public static final int DOUBLE_SHOT = 13001003;
     public static final int STORM = 13001004;
+    // 2nd job
     public static final int BOW_MASTERY = 13100000;
     public static final int BOW_BOOSTER = 13101001;
     public static final int FINAL_ATTACK = 13101002;
     public static final int SOUL_ARROW = 13101003;
+    public static final int THRUST = 13100004;
     public static final int STORM_BREAK = 13101005;
     public static final int WIND_WALK = 13101006;
+    // 3rd job
+    public static final int ARROW_RAIN = 13111000;
     public static final int HURRICANE = 13111002;
+    public static final int BOW_EXPERT = 13110003;
     public static final int PUPPET = 13111004;
     public static final int EAGLE_EYE = 13111005;
     public static final int WIND_PIERCING = 13111006;
     public static final int WIND_SHOT = 13111007;
+    public static final int STRAFE = 13111001;
 }


### PR DESCRIPTION
Resolves #42 

No existing skill ID values were touched, so this is a non-breaking change.

Cross referenced the BBB Hidden-Street website with the skill handbook included.  For KoC and Aran, also reordered/grouped the skills based on job advancement level.

Did not touch Evan - I have never played an Evan and have no idea what's going on with the multiple mastery levels :) So some skills may be missing there.