### PR TITLE
Fix implementation of primary explorer title quests

### DIFF
--- a/scripts/map/onUserEnter/explorationPoint.js
+++ b/scripts/map/onUserEnter/explorationPoint.js
@@ -31,7 +31,7 @@ function start(ms) {
         ms.explorerQuest(29014, "Sleepywood Explorer");//Sleepywood Explorer
     } else if (ms.getPlayer().getMapId() >= 200000000 && ms.getPlayer().getMapId() <= 211041800) {
         ms.explorerQuest(29006, "El Nath Mts. Explorer");//El Nath Mts. Explorer
-    } else if (ms.getPlayer().getMapId() >= 220000000 && ms.getPlayer().getMapId() <= 222010400) {
+    } else if (ms.getPlayer().getMapId() >= 220000000 && ms.getPlayer().getMapId() <= 222020000) {
         ms.explorerQuest(29007, "Ludus Lake Explorer");//Ludus Lake Explorer
     } else if (ms.getPlayer().getMapId() >= 230000000 && ms.getPlayer().getMapId() <= 230040401) {
         ms.explorerQuest(29008, "Undersea Explorer");//Undersea Explorer

--- a/src/main/java/scripting/map/MapScriptMethods.java
+++ b/src/main/java/scripting/map/MapScriptMethods.java
@@ -121,9 +121,8 @@ public class MapScriptMethods extends AbstractPlayerInteraction {
 
         // explorer quests all have an infoex/infonumber requirement that points to another quest
         // THAT quest's progress needs to be updated for Quest.canComplete() to return true
-        getPlayer().getQuest((int)quest.getInfoNumber(qs.getStatus())).setProgress(0, status);
+        getPlayer().setQuestProgress(quest.getId(), (int)quest.getInfoNumber(qs.getStatus()), status);
 
-        getPlayer().announceUpdateQuest(DelayedQuestUpdate.UPDATE, qs, true);
         StringBuilder smp = new StringBuilder();
         StringBuilder etm = new StringBuilder();
         if (status.equals(infoex)) {

--- a/src/main/java/scripting/map/MapScriptMethods.java
+++ b/src/main/java/scripting/map/MapScriptMethods.java
@@ -103,6 +103,10 @@ public class MapScriptMethods extends AbstractPlayerInteraction {
 
     public void explorerQuest(short questid, String questName) {
         Quest quest = Quest.getInstance(questid);
+        if (isQuestCompleted(questid)) {
+            return;
+        }
+        
         if (!isQuestStarted(questid)) {
             if (!quest.forceStart(getPlayer(), 9000066)) {
                 return;

--- a/src/main/java/scripting/map/MapScriptMethods.java
+++ b/src/main/java/scripting/map/MapScriptMethods.java
@@ -114,6 +114,11 @@ public class MapScriptMethods extends AbstractPlayerInteraction {
         }
         String status = Integer.toString(qs.getMedalProgress());
         String infoex = qs.getInfoEx(0);
+
+        // explorer quests all have an infoex/infonumber requirement that points to another quest
+        // THAT quest's progress needs to be updated for Quest.canComplete() to return true
+        getPlayer().getQuest((int)quest.getInfoNumber(qs.getStatus())).setProgress(0, status);
+
         getPlayer().announceUpdateQuest(DelayedQuestUpdate.UPDATE, qs, true);
         StringBuilder smp = new StringBuilder();
         StringBuilder etm = new StringBuilder();


### PR DESCRIPTION
This was a fun one...

The explorer title quests (e.g. Beginner Explorer - Quest IDs 29005, 29006, 29007, 29008, 29009, 29010, 29011, 29014) (excludes titles that are a combination of other titles) all have an `infoex` and `infoNumber` end condition.  `infoex` stores the number of regions that need to be visited; `infoNumber` stores a pointer to a secondary, internal-only quest ID for tracking progress (I think this is usually the same as the primary quest ID).  In `canQuestByInfoProgress()`, this `infoNumber` "quest" is whose progress is checked against `infoex`.

No progress was being set for these anywhere - I added the quest update to the same handler that registers the medal maps as being visited in the first place.

Also fixes a bug where the Ludus Lake Explorer quest can't be completed (Helios Tower <Library> was missing from the explorationPoint.js logic)

![image](https://user-images.githubusercontent.com/52503242/185629686-cac47b9e-f073-4170-b8e0-77c72361a74a.png)

![image](https://user-images.githubusercontent.com/52503242/185629754-22cd77dc-ffa5-4679-b987-ee52fca49a9a.png)

![image](https://user-images.githubusercontent.com/52503242/185632062-23f4215d-894e-45f4-9e86-08549ad08a9e.png)

This also fixed the progress in the medal window to show the number of maps you've visited:

![image](https://user-images.githubusercontent.com/52503242/185629604-505ae1f8-8426-4ae7-b385-16e67c211473.png)
