### PR TITLE
Add portal script for Hidden Street: Secret Passage

### DIFF
--- a/scripts/npc/2040003.js
+++ b/scripts/npc/2040003.js
@@ -12,6 +12,7 @@ function start() {
         status++;
     } else {
         cm.sendOk("Access to #bToy Factory<Sector 4>#k is restricted to the public.");
+        cm.dispose();
     }
 }
 

--- a/scripts/portal/ludi021.js
+++ b/scripts/portal/ludi021.js
@@ -1,0 +1,13 @@
+/*
+    Exit Portal
+    Map: Hidden Street: Secret Passage (922000009)
+    - Remove quest items from player's inventory (Mechanical Parts - 4031092)
+    - Returns user to Toy Factory <Aparatus Room> - 220020600
+    - Reactors are reset and shuffled in map entry script, not included here
+*/
+
+function enter(pi) {
+    pi.removeAll(4031092);
+    pi.warp(220020600)
+    return true;
+}

--- a/scripts/reactor/2202002.js
+++ b/scripts/reactor/2202002.js
@@ -29,7 +29,5 @@
 function act() {
     if (rm.isQuestActive(3238)) {
         rm.warp(922000020, 0);
-    } else {
-        rm.warp(922000009, 0);
     }
 }


### PR DESCRIPTION
It was discovered that there is a difference in clean vs modified WZ files for this portal.  Clean WZ files expect to execute a `ludi021` script, which does not exist and was causing problems for some users who are using clean WZ files on their server/client.

This adds a script handler for this portal.  It will be unused by users running stock Cosmic (provided WZ/XML includes a normal warp handler to the Aparatus Room map), but called by users with clean WZ/XML files.  The script handler will remove the quest item(s) from the user's inventory, and then warp them to Toy Factory <Aparatus Room>.

I did not touch the wz/.../922000009.img.xml file, to keep it consistent with the provided .wz files, but the only difference for this map between a clean file and the included are in portal[2]:

```
      <int name="tm" value="999999999"/>
      <string name="tn" value=""/>
      <string name="script" value="ludi021"/>
```

The NPC/map entry actions were left untouched to ensure that users with the modified WZ files aren't affected by the portal script changes.

Also fixes 2 issues that are close to this quest:
- Base NPC dialogue for Assistant Cheng if you haven't started the quest was not disposed
- Reactors in map 220020600 (Toy Factory <Aparatus Room>) would warp you to the quest room for 3238 if it was active, and warp you to Secret Passage (exit map for quest 3239) if not.  Now the reactors only respond if quest 3238 is active and warps them to the quest room, otherwise the box just poofs and vanishes like any other no-action reactor.