### PR TITLE
Rework quest 3239: The Missing Mechanical Parts

### DIFF
--- a/scripts/event/q3239.js
+++ b/scripts/event/q3239.js
@@ -10,6 +10,7 @@ function init() {
 
 function setup(level, lobbyid) {
     var eim = em.newInstance("q3239_" + lobbyid);
+    eim.setExclusiveItems([4031092]);
     return eim;
 }
 

--- a/scripts/event/q3239.js
+++ b/scripts/event/q3239.js
@@ -1,0 +1,73 @@
+var entryMap;
+var exitMap;
+var eventLength = 20;
+
+function init() {
+    em.setProperty("noEntry", "false");
+    entryMap = em.getChannelServer().getMapFactory().getMap(922000000);
+    exitMap = em.getChannelServer().getMapFactory().getMap(922000009);
+}
+
+function setup(level, lobbyid) {
+    var eim = em.newInstance("q3239_" + lobbyid);
+    return eim;
+}
+
+function playerEntry(eim, player) {
+    var im = eim.getInstanceMap(entryMap.getId());
+
+    // Reset instance
+    im.clearDrops();
+    im.resetReactors();
+    im.shuffleReactors();
+
+    // Start timer
+    eim.startEventTimer(eventLength * 60 * 1000);
+
+    // Warp player and mark event as occupied
+    player.changeMap(entryMap, 0);
+    em.setProperty("noEntry", "true");
+}
+
+function changedMap(eim, player, mapid) {
+    if (mapid != entryMap.getId())
+        playerExit(eim, player);
+}
+
+function playerExit(eim, player) {
+    end(eim);
+}
+
+function playerDisconnected(eim, player) {
+    end(eim);
+}
+
+function scheduledTimeout(eim) {
+    end(eim);
+}
+
+function end(eim) {
+    var party = eim.getPlayers(); // should only ever be one player
+    for (var i = 0; i < party.size(); i++) {
+        var player = party.get(i);
+        eim.unregisterPlayer(player);
+        player.changeMap(exitMap);
+    }
+
+    eim.dispose();
+    em.setProperty("noEntry", "false");
+}
+
+// Stub/filler functions
+
+function disbandParty(eim, player) {}
+function afterSetup(eim) {}
+function playerUnregistered(eim, player) {}
+function changedLeader(eim, leader) {}
+function leftParty(eim, player) {}
+function clearPQ(eim) {}
+function dispose() {}
+function cancelSchedule() {}
+function allMonstersDead(eim) {}
+function monsterValue(eim, mobId) {}
+function monsterKilled(mob, eim) {}

--- a/scripts/npc/2040003.js
+++ b/scripts/npc/2040003.js
@@ -12,6 +12,7 @@ function start() {
         status++;
     } else {
         cm.sendOk("Access to #bToy Factory<Sector 4>#k is restricted to the public.");
+        cm.dispose();
     }
 }
 

--- a/scripts/npc/2040003.js
+++ b/scripts/npc/2040003.js
@@ -1,51 +1,48 @@
 var status = 0;
-var entry;
+var em;
+var eim;
+
+function sendBaseText() {
+    cm.sendOk("Access is restricted to the public.");
+    cm.dispose();
+}
 
 function start() {
-    if (cm.getPlayer().getMapId() == 922000000) {
-        entry = 0;
-        cm.sendYesNo("Do you wish to quit this stage?");
-        status++;
-    } else if (cm.isQuestStarted(3239)) {
-        entry = 1;
-        cm.sendYesNo("Do you want to enter #bToy Factory<Sector 4>#k?");
-        status++;
-    } else {
-        cm.sendOk("Access to #bToy Factory<Sector 4>#k is restricted to the public.");
-        cm.dispose();
+    em = cm.getEventManager("q3239");
+    if (em != null)
+        eim = cm.getEventInstance();
+
+    if (em == null) { // No event handler
+        sendBaseText();
+        return;
+    }
+    else if (eim == null && !cm.isQuestStarted(3239)) { // Not in instance, quest is not in progress
+        sendBaseText();
+        return;
+    }
+
+    if (eim == null) { // Not in instance
+        cm.sendYesNo("Are you ready to enter #b#m922000000##k?");
+    }
+    else { // Inside the instance
+        cm.sendYesNo("Are you ready to leave this place?");
     }
 }
 
 function action(mode, type, selection) {
-    if (status == 1) {
-        if (entry == 0) {
-            if (mode <= 0) {
-                cm.sendOk("Ok. Call me if you urge to exit, then.");
-                cm.dispose();
-                return;
-            }
+    if (mode < 1) {
+        cm.dispose();
+        return;
+    }
 
-            cm.warp(922000009, 0);
-            if (!(cm.isQuestStarted(3239) && cm.haveItem(4031092, 10))) {
-                cm.removeAll(4031092);
-            }
-            cm.dispose();
-        } else {
-            if (mode <= 0) {
-                cm.dispose();
-                return;
-            }
-
-            if (cm.getWarpMap(922000000).countPlayers() == 0) {
-                cm.warp(922000000, 0);
-                if (!(cm.isQuestStarted(3239) && cm.haveItem(4031092, 10))) {
-                    cm.removeAll(4031092);
-                }
-            } else {
-                cm.sendOk("Someone else is already attempting the parts. Wait for them to finish before you enter.");
-            }
-
-            cm.dispose();
+    if (eim == null) { // Not in instance, ready to enter
+        cm.removeAll(4031092); // This doesn't belong here - these should be removed on exit, handled by portal script
+        if (!em.startInstance(cm.getPlayer())) {
+            cm.sendOk("Someone else is already gathering some parts for me. Please wait until the area is cleared.");
         }
     }
+    else { // Inside the instance, ready to exit
+        eim.removePlayer(cm.getPlayer()); // This will end the event and warp the player out
+    }
+    cm.dispose();
 }

--- a/scripts/npc/2040003.js
+++ b/scripts/npc/2040003.js
@@ -36,7 +36,7 @@ function action(mode, type, selection) {
     }
 
     if (eim == null) { // Not in instance, ready to enter
-        cm.removeAll(4031092); // This doesn't belong here - these should be removed on exit, handled by portal script
+        cm.removeAll(4031092); // This handling is done in the portal script and in the event end, just for legacy purposes here
         if (!em.startInstance(cm.getPlayer())) {
             cm.sendOk("Someone else is already gathering some parts for me. Please wait until the area is cleared.");
         }

--- a/scripts/portal/ludi021.js
+++ b/scripts/portal/ludi021.js
@@ -1,0 +1,13 @@
+/*
+    Exit Portal
+    Map: Hidden Street: Secret Passage (922000009)
+    - Remove quest items from player's inventory (Mechanical Parts - 4031092)
+    - Returns user to Toy Factory <Aparatus Room> - 220020600
+    - Reactors are reset and shuffled when event instance is created - not here
+*/
+
+function enter(pi) {
+    pi.removeAll(4031092);
+    pi.warp(220020600);
+    return true;
+} 


### PR DESCRIPTION
* Fixes bug in script for NPC 2040003 (Cheng the Assistant) where dialogue was not disposed
* Adds a default portal handler for the exit portal in map 922000009 (Hidden Street: Secret Passage), which allows for compatibility with clean WZ files
* Reworks quest 3239 (The Missing Mechanical Parts) to be an instanced event.  This is how it is/was in the original MS as far as I can tell from these two YT videos: [[1]](https://www.youtube.com/watch?v=Vtb37mYbxTY&t=17s) and [[2]](https://www.youtube.com/watch?v=Vtb37mYbxTY&t=17s).  Have confirmed that the instances work appropriately (does not warp whole party, only the active user; can have two separate and unrelated instances from different characters in the same world/channel)

![image](https://user-images.githubusercontent.com/52503242/191597796-184091a8-29bf-405f-95b0-54333ecc59b9.png)

Re: the portal handler script - I am not sure what that portal handler script is actually supposed to do.  It was suggested in the discord that it removes the items / resets and shuffles the reactors / etc, but since it's an instanced event, that's taken care of in the event handle script.  I have it remove the items anyway just in case (prevents smuggling maybe?) and then warp the player to the exit map.

Re: the event handler script - this was my first foray into an instanced event so it may have redundant/unnecessary/incorrect code (e.g. the noEntry flag) but it does function as expected as far as I can tell.