### PR TITLE
Add handler for Land of Wild Boar's ritual stones

### DIFF
--- a/scripts/reactor/1029000.js
+++ b/scripts/reactor/1029000.js
@@ -1,0 +1,5 @@
+function act() {
+    rm.killMonster(3230300);
+    rm.killMonster(3230301);
+    rm.message("The Jr. Boogies have been scared away.");
+}

--- a/src/main/java/scripting/reactor/ReactorActionManager.java
+++ b/src/main/java/scripting/reactor/ReactorActionManager.java
@@ -267,6 +267,20 @@ public class ReactorActionManager extends AbstractPlayerInteraction {
         }
     }
 
+    public void killMonster(int id) {
+        killMonster(id, false);
+    }
+
+    public void killMonster(int id, boolean withDrops) {
+        MapleMap map = getMap();
+        if (withDrops) {
+            map.killMonsterWithDrops(id);
+        }
+        else {
+            map.killMonster(id);
+        }
+    }
+
     public Point getPosition() {
         Point pos = reactor.getPosition();
         pos.y -= 10;

--- a/src/main/java/scripting/reactor/ReactorActionManager.java
+++ b/src/main/java/scripting/reactor/ReactorActionManager.java
@@ -272,12 +272,11 @@ public class ReactorActionManager extends AbstractPlayerInteraction {
     }
 
     public void killMonster(int id, boolean withDrops) {
-        MapleMap map = getMap();
         if (withDrops) {
-            map.killMonsterWithDrops(id);
+            getMap().killMonsterWithDrops(id);
         }
         else {
-            map.killMonster(id);
+            getMap().killMonster(id);
         }
     }
 


### PR DESCRIPTION
Fixes #132 

Confirmed that hitting the stones do not grant XP or drops from the Jr. Boogies.  I did add a second `killMonster()` method to allow for a reactor that kills mobs to also drop, just in case there are cases where that's useful, but it's just not used here.

![image](https://user-images.githubusercontent.com/52503242/191618111-096ddbbc-1406-4ab6-9247-7fa2b5db53fb.png)

I also noticed these reactors don't quite finish their animation, not sure where that issue lies - but it occurs regardless of this change.