### PR TITLE
Fix MapId for Southperry from old inaccessible map to correct one

### DIFF
--- a/src/main/java/constants/id/MapId.java
+++ b/src/main/java/constants/id/MapId.java
@@ -22,7 +22,7 @@ public class MapId {
     public static final int MUSHROOM_TOWN = 10000;
 
     // Town
-    public static final int SOUTHPERRY = 60000;
+    public static final int SOUTHPERRY = 2000000;
     public static final int AMHERST = 1000000;
     public static final int HENESYS = 100000000;
     public static final int ELLINIA = 101000000;


### PR DESCRIPTION
Fixes https://github.com/P0nk/Cosmic/issues/113

60000 references an old version of Southperry that is inaccessible normally.
2000000 points to the "real" one.