### PR TITLE
Update ritual stone reactor script (see PR 135 discussion)

### DIFF
--- a/scripts/reactor/1029000.js
+++ b/scripts/reactor/1029000.js
@@ -1,5 +1,7 @@
 function act() {
-    rm.killMonster(3230300);
-    rm.killMonster(3230301);
-    rm.message("The Jr. Boogies have been scared away.");
+    if (rm.isAllReactorState(1029000, 0x04)) { // 0x04 appears to be the destroyed state
+        rm.killMonster(3230300);
+        rm.killMonster(3230301);
+        rm.playerMessage(6, "Once the rock crumbled, Jr. Boogie was in great pain and disappeared.");
+    }    
 }


### PR DESCRIPTION
Per note from @tim78245 in #135 -- this updates the reactors to function the same as they did in EMS (which is presumably the same as they worked in GMS?).  Both reactors must be destroyed, and the message has been updated to match.

(Ignore the NPCs :-) Just from some other testing)

![image](https://user-images.githubusercontent.com/52503242/192059775-ec212a29-81d7-477e-a192-909bf00f43a0.png)