### PR TITLE
Tag the merge commit instead of last commit in the PR

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -2,9 +2,7 @@
 
 name: Bump version
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - master
 


### PR DESCRIPTION
The merge commit is more suitable since it provides some context and groups up all the commits.