### PR TITLE
Fix writeString not fully respecting charset

### DIFF
--- a/src/main/java/net/packet/ByteBufOutPacket.java
+++ b/src/main/java/net/packet/ByteBufOutPacket.java
@@ -71,8 +71,9 @@ public class ByteBufOutPacket implements OutPacket {
 
     @Override
     public void writeString(String value) {
-        writeShort((short) value.length());
-        writeBytes(value.getBytes(CharsetConstants.CHARSET));
+        byte[] bytes = value.getBytes(CharsetConstants.CHARSET);
+        writeShort(bytes.length);
+        writeBytes(bytes);
     }
 
     @Override


### PR DESCRIPTION
The string would be cut short for charsets
with characters more than 1 byte.