### PR TITLE
Update XMLDomMapleData.java

### DIFF
--- a/src/main/java/client/SkillFactory.java
+++ b/src/main/java/client/SkillFactory.java
@@ -38,25 +38,26 @@ public class SkillFactory {
         return skills.get(id);
     }
 
-    public static void loadAllSkills() {
-        final Map<Integer, Skill> loadedSkills = new HashMap<>();
-        final DataDirectoryEntry root = datasource.getRoot();
-        for (DataFileEntry topDir : root.getFiles()) { // Loop thru jobs
-            if (topDir.getName().length() <= 8) {
-                for (Data data : datasource.getData(topDir.getName())) { // Loop thru each jobs
-                    if (data.getName().equals("skill")) {
-                        for (Data data2 : data) { // Loop thru each jobs
-                            if (data2 != null) {
-                                int skillId = Integer.parseInt(data2.getName());
-                                loadedSkills.put(skillId, loadFromData(skillId, data2));
-                            }
-                        }
-                    }
+    ppublic static void loadAllSkills() {
+    final Map<Integer, Skill> loadedSkills = new HashMap<>();
+    final DataProvider dataProvider = DataProviderFactory.getDataProvider(WZFiles.SKILL);
+    final DataDirectoryEntry root = dataProvider.getRoot();
+
+    for (DataFileEntry jobDir : root.getFiles()) {
+        if (jobDir.getName().length() > 8) continue; // Skip non-job files
+        for (Data skillData : dataProvider.getData(jobDir.getName())) {
+            if (!skillData.getName().equals("skill")) continue; // Skip non-skill data
+            for (Data skill : skillData) {
+                int skillId = Integer.parseInt(skill.getName());
+                Skill loadedSkill = loadFromData(skillId, skill);
+                if (loadedSkill != null) {
+                    loadedSkills.put(skillId, loadedSkill);
                 }
             }
         }
+    }
 
-        skills = loadedSkills;
+    skills = loadedSkills;
     }
 
     private static Skill loadFromData(int id, Data data) {


### PR DESCRIPTION
Added a child cache to improve performance by caching previously accessed child nodes.
Added a data cache to improve performance by caching previously accessed data values.
Implemented lazy loading of child nodes to improve performance and reduce memory usage.
Added a nodeToString method to convert a Node object to a unique string representation.
Removed unnecessary catch blocks in the constructor to simplify the code.
Changed the switch statement in getData to cache data values before returning them.

Original Code : +1:  Changes ->

No caching mechanism
The original code eagerly loaded all child nodes when getChildren was called, even if they were not immediately needed. This can be an expensive operation, especially for large XML documents with many child nodes. (Mob.wz, Map.wz) and in later version of the game this will take a toll on it system.

Please feel free to improve it, unless you have any other way to get rid of XML loading, furthermore you can get rid of the wz loading it is beyond rubbish right now, while the mcdb tool was never public and reNX Library, I don't think it was maintain after while atleast for java version, I think this should be okay for now unless you have a better idea on improve the xml storing or loading which the changes should help.