### PR TITLE
Fix exploit with Duey Send Items

### DIFF
--- a/src/main/java/client/processor/npc/DueyProcessor.java
+++ b/src/main/java/client/processor/npc/DueyProcessor.java
@@ -285,7 +285,7 @@ public class DueyProcessor {
         if (c.tryacquireClient()) {
             try {
                 int fee = Trade.getFee(sendMesos);
-                if (sendMessage.length() > 100) {
+                if (sendMessage != null && sendMessage.length() > 100) {
                     AutobanFactory.PACKET_EDIT.alert(c.getPlayer(), c.getPlayer().getName() + " tried to packet edit with Quick Delivery on duey.");
                     log.warn("Chr {} tried to use duey with too long of a text", c.getPlayer().getName());
                     c.disconnect(true, false);

--- a/src/main/java/client/processor/npc/DueyProcessor.java
+++ b/src/main/java/client/processor/npc/DueyProcessor.java
@@ -285,6 +285,12 @@ public class DueyProcessor {
         if (c.tryacquireClient()) {
             try {
                 int fee = Trade.getFee(sendMesos);
+                if (sendMessage.length() > 100) {
+                    AutobanFactory.PACKET_EDIT.alert(c.getPlayer(), c.getPlayer().getName() + " tried to packet edit with Quick Delivery on duey.");
+                    log.warn("Chr {} tried to use duey with too long of a text", c.getPlayer().getName());
+                    c.disconnect(true, false);
+                    return;
+                }
                 if (!quick) {
                     fee += 5000;
                 } else if (!c.getPlayer().haveItem(ItemId.QUICK_DELIVERY_TICKET)) {


### PR DESCRIPTION
On behalf of Shahar#2563
"code permits to send limitless text when sending a package with quick delivery using the npc duey, even tho the sql server stores it in a string that can only contain upto 200 chars, its better to patch this"