### PR TITLE
Use Eclipse Temurin images in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #
 # Cosmic JAR creation stage
 #
-FROM maven:3.8.4-openjdk-17 AS jar
+FROM maven:3.9.1-eclipse-temurin-17 AS jar
 
 # Build in a separated location which won't have permissions issues.
 WORKDIR /opt/cosmic
@@ -21,7 +21,7 @@ RUN mvn -f ./pom.xml clean package -Dmaven.test.skip -T 1C
 #
 # Server creation stage
 #
-FROM openjdk:17.0.2
+FROM eclipse-temurin:17.0.6_10-jre
 
 # Host the server in a location that won't have permissions issues.
 WORKDIR /opt/server


### PR DESCRIPTION
[The OpenJDK Docker images are deprecated](https://hub.docker.com/_/openjdk) and the following error occurs when I run `docker compose up` on Windows:

```text
 => ERROR [jar 4/6] RUN mvn -f ./pom.xml clean dependency:go-offline -Dmaven.test.skip -T 1C                                    0.4s 
------
 > [jar 4/6] RUN mvn -f ./pom.xml clean dependency:go-offline -Dmaven.test.skip -T 1C:
#0 0.332 Error: dl failure on line 542
#0 0.332 Error: failed /usr/java/openjdk-17/lib/server/libjvm.so, because /usr/java/openjdk-17/lib/server/libjvm.so: file too short  
------
failed to solve: executor failed running [/bin/sh -c mvn -f ./pom.xml clean dependency:go-offline -Dmaven.test.skip -T 1C]: exit code: 6
```

Switching to the Eclipse Temurin images solves this.