### PR TITLE
Fix mini-dungeon portals for parties

### DIFF
--- a/src/main/java/scripting/AbstractPlayerInteraction.java
+++ b/src/main/java/scripting/AbstractPlayerInteraction.java
@@ -133,6 +133,16 @@ public class AbstractPlayerInteraction {
         warpParty(id, portalId, mapid, mapid);
     }
 
+    public void warpParty(int map, String portalName) {
+
+        int mapid = getMapId();
+        var warpMap = c.getChannelServer().getMapFactory().getMap(map);
+        var portal = warpMap.getPortal(portalName).getId();
+
+        warpParty(map, portal, mapid, mapid);
+
+    }
+
     public void warpParty(int id, int fromMinId, int fromMaxId) {
         warpParty(id, 0, fromMinId, fromMaxId);
     }

--- a/src/main/java/scripting/AbstractPlayerInteraction.java
+++ b/src/main/java/scripting/AbstractPlayerInteraction.java
@@ -137,9 +137,16 @@ public class AbstractPlayerInteraction {
 
         int mapid = getMapId();
         var warpMap = c.getChannelServer().getMapFactory().getMap(map);
-        var portal = warpMap.getPortal(portalName).getId();
 
-        warpParty(map, portal, mapid, mapid);
+        var portal = warpMap.getPortal(portalName);
+
+        if (portal == null) {
+            portal = warpMap.getPortal(0);
+        }
+
+        var portalId = portal.getId();
+
+        warpParty(map, portalId, mapid, mapid);
 
     }
 


### PR DESCRIPTION
Mini-dungeons are functional for solo use but when entering with a party you get the portal sound but nothing happens. Non-leaders correctly get the notification that they must be the party leader or enter solo.

Summary: `warpParty` was missing an overload that took in the destination map and portal name. There was a solo variant on `AbstractPlayerInteraction` so modeled it after that.

Explanation:
When a party leader tries to enter the portal the Graal Javascript Engine pops an exception that it cannot find warpParty on PortalPlayerInteraction. `org.graalvm.polyglot.PolyglotException: TypeError: invokeMember (warpParty) on scripting.portal.PortalPlayerInteraction failed due to: no applicable overload found `

Portals for mini-dungeons use the script system to enter dungeons. All of the `MD_XXXXXXX` scripts are the ones related to this.

The relevant section in one of the scripts is

```
} else {
    for (var i = 0; i < dungeons; i++) {
        if (pi.startDungeonInstance(dungeonid + i)) {
            pi.playPortalSound();
            pi.warp(dungeonid + i, "out00");
            return true;
        }
    }
}
```

It is looping through the instances of the dungeons that are available and seeing if it can start it. `pi.warp(dungeonid + i, "out00");` is where the exception is thrown.

After patching in the new warpParty overload method everything works well. This has only been tested on 3 mini-dungeons but from a glance they all were implemented the same and suffering the same issue.