### PR TITLE
Delivery System - Invalid Recipient Name Patch

### DIFF
--- a/src/main/java/client/processor/npc/DueyProcessor.java
+++ b/src/main/java/client/processor/npc/DueyProcessor.java
@@ -316,27 +316,22 @@ public class DueyProcessor {
                     return;
                 }
 
-                Pair<Integer, Integer> accIdCid;
-                if (c.getPlayer().getMeso() >= finalcost) {
-                    accIdCid = getAccountCharacterIdFromCNAME(recipient);
-                    int recipientAccId = accIdCid.getLeft();
-                    if (recipientAccId != -1) {
-                        if (recipientAccId == c.getAccID()) {
-                            c.sendPacket(PacketCreator.sendDueyMSG(DueyProcessor.Actions.TOCLIENT_SEND_SAMEACC_ERROR.getCode()));
-                            return;
-                        }
-                    } else {
-                        c.sendPacket(PacketCreator.sendDueyMSG(DueyProcessor.Actions.TOCLIENT_SEND_NAME_DOES_NOT_EXIST.getCode()));
-                        return;
-                    }
-                } else {
+                if(c.getPlayer().getMeso() < finalcost) {
                     c.sendPacket(PacketCreator.sendDueyMSG(DueyProcessor.Actions.TOCLIENT_SEND_NOT_ENOUGH_MESOS.getCode()));
                     return;
                 }
 
-                int recipientCid = accIdCid.getRight();
-                if (recipientCid == -1) {
+                var accIdCid = getAccountCharacterIdFromCNAME(recipient);
+                var recipientAccId = accIdCid.getLeft();
+                var recipientCid = accIdCid.getRight();
+
+                if (recipientAccId == -1 || recipientCid == -1) {
                     c.sendPacket(PacketCreator.sendDueyMSG(DueyProcessor.Actions.TOCLIENT_SEND_NAME_DOES_NOT_EXIST.getCode()));
+                    return;
+                }
+
+                if (recipientAccId == c.getAccID()) {
+                    c.sendPacket(PacketCreator.sendDueyMSG(DueyProcessor.Actions.TOCLIENT_SEND_SAMEACC_ERROR.getCode()));
                     return;
                 }
 

--- a/src/main/java/client/processor/npc/DueyProcessor.java
+++ b/src/main/java/client/processor/npc/DueyProcessor.java
@@ -92,14 +92,15 @@ public class DueyProcessor {
     }
 
     private static Pair<Integer, Integer> getAccountCharacterIdFromCNAME(String name) {
-        Pair<Integer, Integer> ids = null;
+        Pair<Integer, Integer> ids = new Pair<>(-1, -1);
         try (Connection con = DatabaseConnection.getConnection();
              PreparedStatement ps = con.prepareStatement("SELECT id,accountid FROM characters WHERE name = ?")) {
             ps.setString(1, name);
 
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    ids = new Pair<>(rs.getInt("accountid"), rs.getInt("id"));
+                    ids.left = rs.getInt("accountid");
+                    ids.right = rs.getInt("id");
                 }
             }
         } catch (SQLException e) {


### PR DESCRIPTION
The database code for retrieving the account and character id of the submitted recipient returns null if the character does not exist. The calling code in the `DueyProcessor `assumes that this is never null and from inspecting the conditional checks instead is expecting -1 for not found.

This patch updates the `getAccountCharacterIdFromCNAME` method to return `(-1,-1)` in the event that the character is not found.

It also has a minor refactor of the relevant conditional checks to the control statements that consume this result. It removes the nested control flow and bails out as early as possible to reduce cognitive load.