### PR TITLE
Implement progress rate

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ worlds:
     drop_rate: 10
     boss_drop_rate: 10                      #NOTE: Boss drop rate OVERRIDES common drop rate, for bosses-only.
     quest_rate: 5                           #Multiplier for Exp & Meso gains when completing a quest. Only available when USE_QUEST_RATE is true. Stacks with server Exp & Meso rates.
+    progress_rate: 1                        #Multiplier for quest mob progress
     fishing_rate: 10                        #Multiplier for success likelihood on meso thrown during fishing.
     travel_rate: 10                         #Means of transportation rides/departs using 1/N of the default time.
 
@@ -371,6 +372,7 @@ server:
 
     #Quest Configuration
     USE_QUEST_RATE: false           #Exp/Meso gained by quests uses fixed server exp/meso rate times quest rate as multiplier, instead of player rates.
+    EXP_RATE_PROGRESS: false        #Exp rate will also affect quest progress rate (i.e. killing a mob while EXP is 3x will count as 3 mob kills)
 
     #Quest Points Configuration
     QUEST_POINT_REPEATABLE_INTERVAL: 25  #Minimum interval between repeatable quest completions for quest points to be awarded.

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -7436,7 +7436,8 @@ public class Character extends AbstractCharacterObject {
                         continue;
                     }
 
-                    if (qs.progress(id)) {
+                    
+                    if (qs.progress(id, getWorldServer().getProgressRate() * (YamlConfig.config.server.EXP_RATE_PROGRESS ? expRate : 1))) {
                         announceUpdateQuest(DelayedQuestUpdate.UPDATE, qs, false);
                         if (qs.getInfoNumber() > 0) {
                             announceUpdateQuest(DelayedQuestUpdate.UPDATE, qs, true);

--- a/src/main/java/client/QuestStatus.java
+++ b/src/main/java/client/QuestStatus.java
@@ -150,18 +150,23 @@ public class QuestStatus {
         return medalProgress;
     }
 
-    public boolean progress(int id) {
+    public boolean progress(int id, int count) {
         String currentStr = progress.get(id);
         if (currentStr == null) {
             return false;
         }
 
         int current = Integer.parseInt(currentStr);
-        if (current >= this.getQuest().getMobAmountNeeded(id)) {
+        int max = this.getQuest().getMobAmountNeeded(id);
+        if (current >= max) {
             return false;
         }
+        
+        current += count;
+        if (current > max)
+        	current = max;
 
-        String str = StringUtil.getLeftPaddedStr(Integer.toString(++current), '0', 3);
+        String str = StringUtil.getLeftPaddedStr(Integer.toString(current), '0', 3);
         progress.put(id, str);
         //this.setUpdated();
         return true;

--- a/src/main/java/client/command/CommandsExecutor.java
+++ b/src/main/java/client/command/CommandsExecutor.java
@@ -339,6 +339,7 @@ public class CommandsExecutor {
         addCommand("droprate", 4, DropRateCommand.class);
         addCommand("bossdroprate", 4, BossDropRateCommand.class);
         addCommand("questrate", 4, QuestRateCommand.class);
+        addCommand("progressrate", 4, ProgressRateCommand.class);
         addCommand("travelrate", 4, TravelRateCommand.class);
         addCommand("fishrate", 4, FishingRateCommand.class);
         addCommand("itemvac", 4, ItemVacCommand.class);

--- a/src/main/java/client/command/commands/gm4/ProgressRateCommand.java
+++ b/src/main/java/client/command/commands/gm4/ProgressRateCommand.java
@@ -1,0 +1,25 @@
+package client.command.commands.gm4;
+
+import client.Character;
+import client.Client;
+import client.command.Command;
+import tools.PacketCreator;
+
+public class ProgressRateCommand extends Command {
+    {
+        setDescription("Set world quest progress rate.");
+    }
+
+    @Override
+    public void execute(Client c, String[] params) {
+        Character player = c.getPlayer();
+        if (params.length < 1) {
+            player.yellowMessage("Syntax: !progressrate <newrate>");
+            return;
+        }
+
+        int rate = Math.max(Integer.parseInt(params[0]), 1);
+        c.getWorldServer().setProgressRate(rate);
+        c.getWorldServer().broadcastPacket(PacketCreator.serverNotice(6, "[Rate] Quest progress rate has been changed to " + rate + "x."));
+    }
+}

--- a/src/main/java/config/ServerConfig.java
+++ b/src/main/java/config/ServerConfig.java
@@ -219,6 +219,7 @@ public class ServerConfig {
 
     //Quest Configuration
     public boolean USE_QUEST_RATE;
+    public boolean EXP_RATE_PROGRESS;
 
     //Quest Points Configuration
     public int QUEST_POINT_REPEATABLE_INTERVAL;

--- a/src/main/java/config/WorldConfig.java
+++ b/src/main/java/config/WorldConfig.java
@@ -11,6 +11,7 @@ public class WorldConfig {
     public int drop_rate = 1;
     public int boss_drop_rate = 1;
     public int quest_rate = 1;
+    public int progress_rate = 1;
     public int travel_rate = 1;
     public int fishing_rate = 1;
 }

--- a/src/main/java/net/server/Server.java
+++ b/src/main/java/net/server/Server.java
@@ -406,6 +406,7 @@ public class Server {
         int droprate = YamlConfig.config.worlds.get(i).drop_rate;
         int bossdroprate = YamlConfig.config.worlds.get(i).boss_drop_rate;
         int questrate = YamlConfig.config.worlds.get(i).quest_rate;
+        int progressrate = YamlConfig.config.worlds.get(i).progress_rate;
         int travelrate = YamlConfig.config.worlds.get(i).travel_rate;
         int fishingrate = YamlConfig.config.worlds.get(i).fishing_rate;
 
@@ -416,7 +417,7 @@ public class Server {
         World world = new World(i,
                 flag,
                 event_message,
-                exprate, droprate, bossdroprate, mesorate, questrate, travelrate, fishingrate);
+                exprate, droprate, bossdroprate, mesorate, questrate, progressrate, travelrate, fishingrate);
 
         Map<Integer, String> channelInfo = new HashMap<>();
         long bootTime = getCurrentTime();

--- a/src/main/java/net/server/world/World.java
+++ b/src/main/java/net/server/world/World.java
@@ -85,6 +85,7 @@ public class World {
     private int bossdroprate;
     private int mesorate;
     private int questrate;
+    private int progressrate;
     private int travelrate;
     private int fishingrate;
     private final String eventmsg;
@@ -161,7 +162,7 @@ public class World {
     private ScheduledFuture<?> timeoutSchedule;
     private ScheduledFuture<?> hpDecSchedule;
 
-    public World(int world, int flag, String eventmsg, int exprate, int droprate, int bossdroprate, int mesorate, int questrate, int travelrate, int fishingrate) {
+    public World(int world, int flag, String eventmsg, int exprate, int droprate, int bossdroprate, int mesorate, int questrate, int progressrate, int travelrate, int fishingrate) {
         this.id = world;
         this.flag = flag;
         this.eventmsg = eventmsg;
@@ -170,8 +171,10 @@ public class World {
         this.bossdroprate = bossdroprate;
         this.mesorate = mesorate;
         this.questrate = questrate;
+        this.progressrate = progressrate;
         this.travelrate = travelrate;
         this.fishingrate = fishingrate;
+        
         runningPartyId.set(1000000001); // partyid must not clash with charid to solve update item looting issues, found thanks to Vcoc
         runningMessengerId.set(1);
 
@@ -397,6 +400,14 @@ public class World {
 
     public void setQuestRate(int quest) {
         this.questrate = quest;
+    }
+
+    public int getProgressRate() {
+        return progressrate;
+    }
+
+    public void setProgressRate(int progress) {
+        this.progressrate = progress;
     }
 
     public int getTravelRate() {


### PR DESCRIPTION
This PR implements the following features:
* Progress rate for mobs (how much do mobs count toward quest progress)
* Settable in config.yaml
* Changeable using the command !progressrate
* Use EXP rate as the progress rate (set EXP_RATE_PROGRESS to true)
* If EXP rate as progress is enabled than it is multiplied with the progress rate (e.g. exp_rate is 3, progress_rate is 7, so each mob will contibute 21 total progress)