### PR TITLE
Fix masking of ip address when connecting locally

### DIFF
--- a/src/main/java/client/Client.java
+++ b/src/main/java/client/Client.java
@@ -39,7 +39,6 @@ import net.server.Server;
 import net.server.channel.Channel;
 import net.server.coordinator.login.LoginBypassCoordinator;
 import net.server.coordinator.session.Hwid;
-import net.server.coordinator.session.IpAddresses;
 import net.server.coordinator.session.SessionCoordinator;
 import net.server.coordinator.session.SessionCoordinator.AntiMulticlientResult;
 import net.server.guild.Guild;
@@ -176,10 +175,7 @@ public class Client extends ChannelInboundHandlerAdapter {
     private static String getRemoteAddress(io.netty.channel.Channel channel) {
         String remoteAddress = "null";
         try {
-            String hostAddress = ((InetSocketAddress) channel.remoteAddress()).getAddress().getHostAddress();
-            if (hostAddress != null) {
-                remoteAddress = IpAddresses.evaluateRemoteAddress(hostAddress); // thanks dyz for noticing Local/LAN/WAN connections not interacting properly
-            }
+            remoteAddress = ((InetSocketAddress) channel.remoteAddress()).getAddress().getHostAddress();
         } catch (NullPointerException npe) {
             log.warn("Unable to get remote address for client", npe);
         }

--- a/src/main/java/net/netty/ServerChannelInitializer.java
+++ b/src/main/java/net/netty/ServerChannelInitializer.java
@@ -15,7 +15,6 @@ import net.encryption.InitializationVector;
 import net.encryption.PacketCodec;
 import net.packet.logging.InPacketLogger;
 import net.packet.logging.OutPacketLogger;
-import net.server.coordinator.session.IpAddresses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tools.PacketCreator;
@@ -35,10 +34,7 @@ public abstract class ServerChannelInitializer extends ChannelInitializer<Socket
     String getRemoteAddress(Channel channel) {
         String remoteAddress = "null";
         try {
-            String hostAddress = ((InetSocketAddress) channel.remoteAddress()).getAddress().getHostAddress();
-            if (hostAddress != null) {
-                remoteAddress = IpAddresses.evaluateRemoteAddress(hostAddress); // thanks dyz for noticing Local/LAN/WAN connections not interacting properly
-            }
+            remoteAddress = ((InetSocketAddress) channel.remoteAddress()).getAddress().getHostAddress();
         } catch (NullPointerException npe) {
             log.warn("Unable to get remote address from netty Channel: {}", channel, npe);
         }

--- a/src/main/java/net/server/channel/handlers/ChangeMapHandler.java
+++ b/src/main/java/net/server/channel/handlers/ChangeMapHandler.java
@@ -29,6 +29,7 @@ import constants.id.ItemId;
 import constants.id.MapId;
 import net.AbstractPacketHandler;
 import net.packet.InPacket;
+import net.server.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import server.Trade;
@@ -181,7 +182,11 @@ public final class ChangeMapHandler extends AbstractPacketHandler {
             c.disconnect(false, false);
             return;
         }
-        String[] socket = c.getChannelServer().getIP().split(":");
+        String[] socket = Server.getInstance().getInetSocket(c, c.getWorld(), c.getChannel());
+        if (socket == null) {
+            c.enableCSActions();
+            return;
+        }
         chr.getCashShop().open(false);
 
         chr.setSessionTransitionState();

--- a/src/main/java/net/server/coordinator/session/IpAddresses.java
+++ b/src/main/java/net/server/coordinator/session/IpAddresses.java
@@ -1,7 +1,5 @@
 package net.server.coordinator.session;
 
-import config.YamlConfig;
-
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -14,14 +12,6 @@ public class IpAddresses {
         return Stream.of("10\\.", "192\\.168\\.", "172\\.(1[6-9]|2[0-9]|3[0-1])\\.")
                 .map(Pattern::compile)
                 .collect(Collectors.toList());
-    }
-
-    public static String evaluateRemoteAddress(String inetAddress) {
-        if (isLocalAddress(inetAddress) || isLanAddress(inetAddress)) {
-            return YamlConfig.config.server.HOST;
-        } else {
-            return inetAddress;
-        }
     }
 
     public static boolean isLocalAddress(String inetAddress) {


### PR DESCRIPTION
The server partially supports remote players connecting & local players connecting by detecting if the ip connecting is a local/lan ip. If it is, the server then properly sends the appropiate local/lan address when doing migrations.

`evaluateRemoteAddress` completely broke that by changing the ip that the server uses to detect if such connection is local/lan to being the hosts address which will be a public ip and such then not detected as a local/lan ip.

I only tested this in 1 scenario. Where I was locally connecting to a server via `127.0.0.1` but the `HOST` was my public ip. Before this fix: crash on migration to channel server, after: successfully transitioned and loaded into henesys & cashshop.

I also noticed https://github.com/P0nk/Cosmic/blob/4fb632ecdbc4c938e21723d0911b6ff6ad3fe7a4/src/main/java/client/Client.java#L172 seems to be completely useless. The `remoteAddress` field is set in the constructor, then set again when channelActive is called. I'd personally just depend on channelActive but that's me and not in the scope of this PR.