### PR TITLE
fix: error flag after use karma

### DIFF
--- a/src/main/java/client/inventory/manipulator/KarmaManipulator.java
+++ b/src/main/java/client/inventory/manipulator/KarmaManipulator.java
@@ -43,7 +43,7 @@ public class KarmaManipulator {
             flag ^= karmaFlag;
             flag |= ItemConstants.UNTRADEABLE;
 
-            item.setFlag((byte) flag);
+            item.setFlag(flag);
         }
     }
 
@@ -53,6 +53,6 @@ public class KarmaManipulator {
 
         flag |= karmaFlag;
         flag &= (0xFFFFFFFF ^ ItemConstants.UNTRADEABLE);
-        item.setFlag((byte) flag);
+        item.setFlag(flag);
     }
 }


### PR DESCRIPTION
setFalg() function is designed to take arguments of type short. Forcing the short type flag to be converted to the byte type causes some errors here.

For example, the equipment merge system will make the UNTRADEABLE flag become 520, combined with the Scissors of Karma 16, and finally become 536, this value is beyond the byte range, and the mandatory variable type will cause the flag error, the specific problem I encountered is that the MERGE_UNTRADEABLE flag is lost after using the Scissors of Karma.

**The way to reproduce this problem is as follows**: 
1. take a untradable equip
2. use the equipment merge system to strengthen the equip
3. use the Scissors of Karma on the equip
4. use this equip as merge material to strengthen other equip, and you will find that it succeeds.

According to the rules, this equipment cannot be used as material to strengthen other equipment, but this bug causes this equipment to lose the MERGE_UNTRADEABLE flag, so this equipment can be used as material to strengthen other equipment.