### PR TITLE
[WIP - DONT MERGE YET] Update docker-compose and documents.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       # Format: WWCC, where WW is 75 plus the world number and CC is 75 plus the channel number (both zero indexed).
       # In this case, world 1 channels 1-3.
       - "7575-7577:7575-7577"
+    hostname: cosmic-maplestory
     volumes:
       # Config changes can be reloaded without rebuilding the image.
       # Still requires a redeployment as they're sourced on startup.
@@ -19,6 +20,7 @@ services:
       - ./wz:/opt/server/wz
     environment:
       DB_HOST: "db" ## Remember if this is present it will OVERRIDE the host in the config.yaml, if you put here anything other than db, you'll need to change the config.yaml jdbc string to port 3307, and not port 3306
+    restart: always
     
   db:
     image: mysql:8.0.23
@@ -29,6 +31,15 @@ services:
       MYSQL_PASSWORD: "snailshell"
     ports:
       - "3307:3306"
+    hostname: cosmic-db
     volumes:
       - ./database/docker-db-data:/var/lib/mysql
       - ./database/sql:/docker-entrypoint-initdb.d
+    restart: always
+
+  adminer:
+    image: adminer
+    ports:
+      - 8080:8080
+    hostname: cosmic-adminer
+    restart: always


### PR DESCRIPTION
This PR contains the following changes

- [x] Update docker-compose.  
	- Add <code>adminer</code>: This allows user to be able to access and edit the database from web browser without installing of other db-manager softwares. Adminer also support other db like posgres, sqlite, ms sql ...  
	- Add <code>restart: always</code> to container config: This will auto start the Cosmic maple server with the host PC (or with the docker service).   

- [ ] Update documents  (WIP)
	- To address the above docker-compose changes.  
	- The current installer/code is great, it worked out of the box. But I think the document(Readme.md) is a little confusing for ppl are unfamiliar with server stuff. (E.g. JDK, IntelliJ, SQL sever/client are not needed if users run the server with docker method.)  

And the last : **The localhost client and hex editor software**. For user want to run the client that connect to sever that not "localhost", they will need to edit the launcher.exe with hex editor. The more flex solution is to supply an EXE pointing at a host name (e.g. maple_svr) instead of a fixed IP. User will only need to add "192.168.xx maple_svr" into their host file instead of have to modify the EXE file with hex editor. I knew that the localhost client is out of scope of this project, but it will be nice to have this option. <- any comment on this method?


Some screenshots of the adminer interface:
![Screenshot_2023-09-13_09-02-52](https://github.com/P0nk/Cosmic/assets/22391265/f6a2e4d3-e261-4ac1-894a-fba2083d9bb4)

![Screenshot_2023-09-13_09-03-16](https://github.com/P0nk/Cosmic/assets/22391265/28e07a3c-48c0-440a-830e-263de41497b5)



Some screenshots of the modified localhost client:
![Screenshot_2023-09-12_23-12-48](https://github.com/P0nk/Cosmic/assets/22391265/fb512cfd-2f81-4916-97e6-0fa26fda3294)


![Screenshot_2023-09-12_23-11-30](https://github.com/P0nk/Cosmic/assets/22391265/56e23a77-d295-4a62-a6fa-c56ef99c36ed)

