### PR TITLE
BugFix: can't give CASH items to player (prepareInventoryItemList)

### DIFF
--- a/src/main/java/scripting/AbstractPlayerInteraction.java
+++ b/src/main/java/scripting/AbstractPlayerInteraction.java
@@ -291,7 +291,7 @@ public class AbstractPlayerInteraction {
         int size = Math.min(itemids.size(), quantity.size());
 
         List<List<Pair<Integer, Integer>>> invList = new ArrayList<>(6);
-        for (int i = InventoryType.UNDEFINED.getType(); i < InventoryType.CASH.getType(); i++) {
+        for (int i = InventoryType.UNDEFINED.getType(); i <= InventoryType.CASH.getType(); i++) {
             invList.add(new LinkedList<>());
         }
 


### PR DESCRIPTION
I noticed the issue when I tried to give an NX item as a quest reward.
Index out of bounds issue.
After debugging I noticed CASH was not included in the invList, changing the loop from '<' to '<=' includes CASH also.