### PR TITLE
Bugfix: unable to complete scipted quests remotely

### DIFF
--- a/src/main/java/scripting/quest/QuestScriptManager.java
+++ b/src/main/java/scripting/quest/QuestScriptManager.java
@@ -107,7 +107,7 @@ public class QuestScriptManager extends AbstractScriptManager {
 
     public void end(Client c, short questid, int npc) {
         Quest quest = Quest.getInstance(questid);
-        if (!c.getPlayer().getQuest(quest).getStatus().equals(QuestStatus.Status.STARTED) || !c.getPlayer().getMap().containsNPC(npc)) {
+        if (!c.getPlayer().getQuest(quest).getStatus().equals(QuestStatus.Status.STARTED) || (!c.getPlayer().getMap().containsNPC(npc) && !quest.isAutoComplete())) {
             dispose(c);
             return;
         }


### PR DESCRIPTION
Wasn't able to complete remote quest (only scripted ones, wz worked). because of a check.
Expanded the check to see if a quest is autocomplete. 
Might need some refactoring for readability though.