### PR TITLE
NPCMoreTalkHandler: don't underflow selection

### DIFF
--- a/src/main/java/net/packet/ByteBufInPacket.java
+++ b/src/main/java/net/packet/ByteBufInPacket.java
@@ -22,6 +22,8 @@ public class ByteBufInPacket implements InPacket {
     public byte readByte() {
         return byteBuf.readByte();
     }
+    @Override
+    public short readUnsignedByte() { return byteBuf.readUnsignedByte(); }
 
     @Override
     public short readShort() {

--- a/src/main/java/net/packet/InPacket.java
+++ b/src/main/java/net/packet/InPacket.java
@@ -4,6 +4,7 @@ import java.awt.*;
 
 public interface InPacket extends Packet {
     byte readByte();
+    short readUnsignedByte();
     short readShort();
     int readInt();
     long readLong();

--- a/src/main/java/net/server/channel/handlers/NPCMoreTalkHandler.java
+++ b/src/main/java/net/server/channel/handlers/NPCMoreTalkHandler.java
@@ -60,6 +60,11 @@ public final class NPCMoreTalkHandler extends AbstractPacketHandler {
                 selection = p.readInt();
             } else if (p.available() > 0) {
                 selection = p.readByte();
+                // If there are more than 127 choices, don't underflow to -128.
+                // This is useful if you want to have more than 127 hairs/faces at a stylist NPC.
+                if (selection < 0) {
+                    selection += 256;
+                }
             }
             if (c.getQM() != null) {
                 if (c.getQM().isStart()) {

--- a/src/main/java/net/server/channel/handlers/NPCMoreTalkHandler.java
+++ b/src/main/java/net/server/channel/handlers/NPCMoreTalkHandler.java
@@ -59,12 +59,7 @@ public final class NPCMoreTalkHandler extends AbstractPacketHandler {
             if (p.available() >= 4) {
                 selection = p.readInt();
             } else if (p.available() > 0) {
-                selection = p.readByte();
-                // If there are more than 127 choices, don't underflow to -128.
-                // This is useful if you want to have more than 127 hairs/faces at a stylist NPC.
-                if (selection < 0) {
-                    selection += 256;
-                }
+                selection = p.readUnsignedByte();
             }
             if (c.getQM() != null) {
                 if (c.getQM().isStart()) {

--- a/src/test/java/net/packet/ByteBufInPacketTest.java
+++ b/src/test/java/net/packet/ByteBufInPacketTest.java
@@ -39,6 +39,36 @@ class ByteBufInPacketTest {
     }
 
     @Test
+    void readUnsignedByte() {
+        final byte writtenByte = Byte.MAX_VALUE;
+        byteBuf.writeByte(writtenByte);
+
+        short readUnsignedByte = inPacket.readUnsignedByte();
+
+        assertEquals(writtenByte, readUnsignedByte);
+    }
+
+    @Test
+    void readUnsignedByte_shouldBeNonnegative() {
+        final byte writtenByte = Byte.MIN_VALUE;
+        byteBuf.writeByte(writtenByte);
+
+        short readUnsignedByte = inPacket.readUnsignedByte();
+
+        assertEquals((short)writtenByte + 256, readUnsignedByte);
+    }
+
+    @Test
+    void readUnsignedByte_shouldBeNonnegative2() {
+        final byte writtenByte = -1;
+        byteBuf.writeByte(writtenByte);
+
+        short readUnsignedByte = inPacket.readUnsignedByte();
+
+        assertEquals((short)writtenByte + 256, readUnsignedByte);
+    }
+
+    @Test
     void readShort() {
         final short writtenShort = 12_345;
         byteBuf.writeShortLE(writtenShort);


### PR DESCRIPTION
Made this change to allow more than 127 hairs/faces to be available at the stylist NPCs, but it could be useful for other custom dialogues that involve many choices. Given that `selection` can also be read from the packet as an int, I think this change makes sense.

I'm not sure when exactly the client sends a byte vs an int for `selection`, so I've only tested it for my own use case. My guess is that a negative `selection` value is never desirable, so I think this change should be pretty safe.