### PR TITLE
Fix bug in PPQ where non-party leader can get stuck in an NPC dialogue loop

### DIFF
--- a/scripts/npc/2094002.js
+++ b/scripts/npc/2094002.js
@@ -23,7 +23,12 @@ function action(mode, type, selection) {
     }
 
     if (!cm.isEventLeader()) {
-        cm.sendYesNo("I wish for your leader to talk to me. Alternatively, you may be wanting to quit. Are you going to abandon this campaign?");
+        // Player chose "No" or "End Chat"
+        if (mode <= 0) {
+            cm.dispose();
+        } else {
+            cm.sendYesNo("I wish for your leader to talk to me. Alternatively, you may be wanting to quit. Are you going to abandon this campaign?");
+        }
     } else {
         var eim = cm.getEventInstance();
         if (eim == null) {


### PR DESCRIPTION
When a (non-leader) party member talks to NPC Guon (2094002) in Pirate PQ, they are given the choice to leave the PQ.

Expected behavior: Pressing "End Chat" or "No" should close the dialogue.

Actual behavior: Pressing "End Chat" or "No" causes the dialogue to repeat. The only ways to exit the dialogue are to press "Yes" (and leave the PQ), quit the game, or involve GM intervention.