### PR TITLE
fix: item lock cant extend lock time

### DIFF
--- a/src/main/java/net/server/channel/handlers/UseCashItemHandler.java
+++ b/src/main/java/net/server/channel/handlers/UseCashItemHandler.java
@@ -228,10 +228,10 @@ public final class UseCashItemHandler extends AbstractPacketHandler {
                     return;
                 }
                 short flag = eq.getFlag();
-                flag |= ItemConstants.LOCK;
                 if (eq.getExpiration() > -1 && (eq.getFlag() & ItemConstants.LOCK) != ItemConstants.LOCK) {
                     return; //No perma items pls
                 }
+                flag |= ItemConstants.LOCK;
                 eq.setFlag(flag);
 
                 long period = 0;

--- a/src/main/java/net/server/channel/handlers/UseCashItemHandler.java
+++ b/src/main/java/net/server/channel/handlers/UseCashItemHandler.java
@@ -229,7 +229,7 @@ public final class UseCashItemHandler extends AbstractPacketHandler {
                 }
                 short flag = eq.getFlag();
                 flag |= ItemConstants.LOCK;
-                if (eq.getExpiration() > -1) {
+                if (eq.getExpiration() > -1 && (eq.getFlag() & ItemConstants.LOCK) != ItemConstants.LOCK) {
                     return; //No perma items pls
                 }
                 eq.setFlag(flag);
@@ -246,7 +246,8 @@ public final class UseCashItemHandler extends AbstractPacketHandler {
                 }
 
                 if (period > 0) {
-                    eq.setExpiration(currentServerTime() + DAYS.toMillis(period));
+                    long expiration = eq.getExpiration() > -1 ? eq.getExpiration() : currentServerTime();
+                    eq.setExpiration(expiration + DAYS.toMillis(period));
                 }
 
                 // double-remove found thanks to BHB


### PR DESCRIPTION
for sealing lock

itemId == 5060001 || itemId == 5061000 || itemId == 5061001 || itemId == 5061002 || itemId == 5061003