### PR TITLE
Ariant Coliseum: Fix score counting and trade conversation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 # Database
 database/docker-db-data
 database/docker-pg-db-data
+
+# macOS files
+.DS_Store

--- a/scripts/npc/2101015.js
+++ b/scripts/npc/2101015.js
@@ -32,14 +32,14 @@ function action(mode, type, selection) {
         } else if (status == 1) {
             if (selection == 0) {
                 apqpoints = cm.getPlayer().getAriantPoints();
-                if (apqpoints < 100) {
-                    cm.sendOk("Your Battle Arena score: #b" + apqpoints + "#k points. You need to surpass #b100 points#k so that I can give you the #bPalm Tree Beach Chair#k. Talk to me again when you have enough points.");
-                    cm.dispose();
+                if (apqpoints >= 100) {
+                    cm.sendNext("Wow, it looks like you got the #b100#k points ready to trade, let's trade?!");
                 } else if (apqpoints + arena.getAriantRewardTier(cm.getPlayer()) >= 100) {
-                    cm.sendOk("Your Battle Arena score: #b" + apqpoints + "#k points and you pratically already have that score! Talk to my wife, #p2101016#to get them and then re-chat with me!");
+                    cm.sendOk("Your Battle Arena score: #b" + apqpoints + "#k points and you pratically already have that score! Talk to my wife, #p2101016# to get them and then re-chat with me!");
                     cm.dispose();
                 } else {
-                    cm.sendNext("Wow, it looks like you got the #b100#k points ready to trade, let's trade?!");
+                    cm.sendOk("Your Battle Arena score: #b" + apqpoints + "#k points. You need to surpass #b100 points#k so that I can give you the #bPalm Tree Beach Chair#k. Talk to me again when you have enough points.");
+                    cm.dispose();
                 }
             } else if (selection == 1) {
                 cm.sendOk("The main objective of the Battle Arena is to allow the player to accumulate points so that they can be traded honorably for the highest prize: the #bPalm Tree Beach Chair#k. Collect points during the battles and talk to me when it's time to get the prize. In each battle, the player is given the opportunity to score points based on the amount of jewelry that the player has at the end. But be careful! If your points distance from other players #ris too high#k, this will have been all for nothing and you will earn mere #r1 point#k only.");

--- a/src/main/java/net/server/channel/handlers/UseCatchItemHandler.java
+++ b/src/main/java/net/server/channel/handlers/UseCatchItemHandler.java
@@ -93,6 +93,7 @@ public final class UseCatchItemHandler extends AbstractPacketHandler {
                                     mob.getMap().killMonster(mob, null, false);
                                     InventoryManipulator.removeById(c, InventoryType.USE, itemId, 1, true, true);
                                     InventoryManipulator.addById(c, ItemId.ARPQ_SPIRIT_JEWEL, (short) 1, "", -1);
+                                    chr.updateAriantScore();
                                 } else {
                                     chr.getMap().broadcastMessage(PacketCreator.catchMonster(monsterid, itemId, (byte) 0));
                                 }


### PR DESCRIPTION
## Score Counting

### Description

The score counting of Ariant Coliseum is broken. Score of a player isn't updated after catching a monster.

### Cause/Solution

Ariant score should be updated whenever a player catching a monster.

## Trade Conversation

### Description

Players can't exchange the "Palm Tree Beach Chair" after earning 100 points.

### Cause/Solution

The order for checking conditions of Ariant point is wrong.
The correct order for checking conditions should be:
1.  Ariant points >= 100 => continue to exchange
2.  Ariant points + reward in this game >= 100 => hint that the player should convert the reward to points first
3.  Otherwise, the player doesn't have enough points to exchange the chair.