### PR TITLE
NPC: Fix type casting error for `gainMeso()` method

### DIFF
--- a/src/main/java/scripting/npc/NPCConversationManager.java
+++ b/src/main/java/scripting/npc/NPCConversationManager.java
@@ -278,6 +278,10 @@ public class NPCConversationManager extends AbstractPlayerInteraction {
         getPlayer().gainMeso(gain);
     }
 
+    public void gainMeso(Double gain) {
+        getPlayer().gainMeso(gain.intValue());
+    }
+
     public void gainExp(int gain) {
         getPlayer().gainExp(gain, true, true);
     }


### PR DESCRIPTION
## Description

`TypeError` occurs when calling `gainMeso()` in NPC js scripts.

![image](https://github.com/P0nk/Cosmic/assets/29587840/7db0411c-0c51-44a2-b33a-97608b48ba45)

## Cause/Solution

When calling `gainMeso()` in NPC js scripts, the passed `number` type parameter will be converted into `Double` type in Java. The `Double` type to `int` type casting might lose precision and thus the implicit casting is discouraged.

My solution is adding a `gainMeso(Double gain)` method in the `NPCConversationManager` class and call the `intValue()` method on the `Double` value to cast the variable explicitly, so that the `TypeError` won't occur anymore.

After this patch, I think the functionality of item makers should be fixed. By the way, I only tested Vicious (Henesys) and JM from tha Streetz (Kerning City).

## Related Issues

#224