### PR TITLE
NPC 2040022.js is removing items even if player does not have all materials to craft it. party3_jailin.js - Map is unpassable as the top layer spears will not hit mobs

### DIFF
--- a/scripts/npc/2040022.js
+++ b/scripts/npc/2040022.js
@@ -198,20 +198,12 @@ function action(mode, type, selection) {
         } else {
             if (mats instanceof Array) {
                 for (var i = 0; complete && i < mats.length; i++) {
-                    if (matQty[i] * selection == 1) {
-                        if (!cm.haveItem(mats[i])) {
+                    if (!cm.haveItem(mats[i], matQty[i])) {
                             complete = false;
-                        }
-                    } else {
-                        if (!cm.haveItem(mats[i], matQty[i] * selection)) {
-                            complete = false;
-                        }
                     }
                 }
             } else {
-                if (!cm.haveItem(mats, matQty * selection)) {
-                    complete = false;
-                }
+                complete = false;
             }
         }
 

--- a/scripts/portal/party3_jailin.js
+++ b/scripts/portal/party3_jailin.js
@@ -1,4 +1,4 @@
-var leverSequenceExit = false;
+var leverSequenceExit = true;
 
 function enterLeverSequence(pi) {
     var map = pi.getMap();


### PR DESCRIPTION
2040022.js - This is due to the checks of material quantity being multiplied by "selection" which is -1 when the user selects OK
party3_jailin.js - Map is unpassable as the top layer spears will not hit mobs