### PR TITLE
Fix mob skill success rate

### DIFF
--- a/src/main/java/server/life/MobSkillFactory.java
+++ b/src/main/java/server/life/MobSkillFactory.java
@@ -99,7 +99,7 @@ public class MobSkillFactory {
             long duration = SECONDS.toMillis(DataTool.getInt("time", skillData, 0));
             long cooltime = SECONDS.toMillis(DataTool.getInt("interval", skillData, 0));
             int iprop = DataTool.getInt("prop", skillData, 100);
-            float prop = iprop / 100;
+            float prop = (float) iprop / 100;
             int limit = DataTool.getInt("limit", skillData, 0);
 
             Data ltData = skillData.getChildByPath("lt");


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

float prop = iprop / 100;

the [commit ](https://github.com/P0nk/Cosmic/commit/f9b328b432c9ed3defdd176f2eae994e0afff76f) use the prop value, but it always get 1.0 or 0.0, even iprop = 50...

that cause the mob skill alway fail, unless the success rate is 100%

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
