### PR TITLE
Surprise Box Implementation

### DIFF
--- a/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
+++ b/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
@@ -41,6 +41,7 @@ public class CashShopSurpriseHandler extends AbstractPacketHandler {
             if (cssResult != null) {
                 Item cssItem = cssResult.getLeft(), cssBox = cssResult.getRight();
                 c.sendPacket(PacketCreator.onCashGachaponOpenSuccess(c.getAccID(), cssBox.getSN(), cssBox.getQuantity(), cssItem, cssItem.getItemId(), cssItem.getQuantity(), true));
+                c.sendPacket(PacketCreator.showCashInventory(c));
             } else {
                 c.sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
             }

--- a/src/main/java/server/CashShop.java
+++ b/src/main/java/server/CashShop.java
@@ -36,6 +36,7 @@ import provider.DataProviderFactory;
 import provider.DataTool;
 import provider.wz.WZFiles;
 import tools.DatabaseConnection;
+import tools.PacketCreator;
 import tools.Pair;
 
 import java.sql.Connection;
@@ -407,6 +408,17 @@ public class CashShop {
         }
     }
 
+    public int getItemsSize() {
+        int size = 0;
+        lock.lock();
+        try {
+            size = inventory.size();
+        } finally {
+            lock.unlock();
+        }
+        return size;
+    }
+
     public List<Integer> getWishList() {
         return wishList;
     }
@@ -544,14 +556,14 @@ public class CashShop {
         Item css = getCashShopItemByItemid(ItemId.CASH_SHOP_SURPRISE);
 
         if (css != null) {
+            if (getItemsSize() >= 100) {
+                return null;
+            }
+
             CashItem cItem = CashItemFactory.getRandomCashItem();
 
             if (cItem != null) {
                 if (css.getQuantity() > 1) {
-                    /* if(NOT ENOUGH SPACE) { looks like we're not dealing with cash inventory limit whatsoever, k then
-                        return null;
-                    } */
-
                     css.setQuantity((short) (css.getQuantity() - 1));
                 } else {
                     removeFromInventory(css);


### PR DESCRIPTION
- Added showCashInventory after a successful gachapon opening in the CashShopSurpriseHandler.
- Added getItemsSize() condition to check the inventory size before proceeding with the cash shop surprise opening

## Description
I have added the following line to show the cash inventory after a successful gachapon opening in the CashShopSurpriseHandler:

> c.sendPacket(PacketCreator.showCashInventory(c));

This line is added within the condition where **cssResult** is not null, right after sending the success packet for the Surprise box open event. This ensures that the cash inventory is displayed to the user upon a successful operation.

and I have added the following condition to check the inventory size before proceeding with the cash shop surprise opening:

> if (getItemsSize() >= 100) {
>     return null;
> }

This line is added at the beginning of the openCashShopSurprise method. It ensures that if the inventory size is greater than or equal to 100, the method will return null and not proceed further. This prevents adding new items when the inventory is full.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
![Record_2024_06_13_20_12_10_882](https://github.com/P0nk/Cosmic/assets/12149565/7d01e9c8-09e1-40b8-b3b7-6c3a03871e63)


