### PR TITLE
Fix cash shop surprise count not properly updated on usage

### DIFF
--- a/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
+++ b/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
@@ -40,8 +40,7 @@ public class CashShopSurpriseHandler extends AbstractPacketHandler {
 
             if (cssResult != null) {
                 Item cssItem = cssResult.getLeft(), cssBox = cssResult.getRight();
-                c.sendPacket(PacketCreator.onCashGachaponOpenSuccess(c.getAccID(), cssBox.getSN(), cssBox.getQuantity(), cssItem, cssItem.getItemId(), cssItem.getQuantity(), true));
-                c.sendPacket(PacketCreator.showCashInventory(c));
+                c.sendPacket(PacketCreator.onCashGachaponOpenSuccess(c.getAccID(), cssBox.getCashId(), cssBox.getQuantity(), cssItem, cssItem.getItemId(), cssItem.getQuantity(), true));
             } else {
                 c.sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
             }


### PR DESCRIPTION
This reverts the hacky solution made in db82cbcfae6f4eca0dc8e21b7f0de4c182b75a14

## Description
Update cash shop surprise count using the existing packet instead of a manual cash shop inventory refresh (which revealed the opened item prematurely).

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
