### PR TITLE
Fix using the last Cash shop surprise not removing the item

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>cosmic-maplestory</groupId>
@@ -52,7 +53,8 @@
         <!-- Maven plugins -->
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version> <!-- For running unit tests -->
         <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version> <!-- Disabled. (for building thin jar) -->
-        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version> <!-- For packaging the executable fat jar -->
+        <maven-assembly-plugin.version>3.7.1
+        </maven-assembly-plugin.version> <!-- For packaging the executable fat jar -->
 
         <!-- Dependencies -->
         <slf4j-api.version>2.0.13</slf4j-api.version> <!-- Logging facade -->
@@ -177,6 +179,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -2068,7 +2068,7 @@ public class Character extends AbstractCharacterObject {
                                 this.getCashShop().gainCash(1, nxGain);
 
                                 if (YamlConfig.config.server.USE_ANNOUNCE_NX_COUPON_LOOT) {
-                                    showHint("You have earned #e#b" + nxGain + " NX#k#n. (" + this.getCashShop().getCash(1) + " NX)", 300);
+                                    showHint("You have earned #e#b" + nxGain + " NX#k#n. (" + this.getCashShop().getCash(CashShop.NX_CREDIT) + " NX)", 300);
                                 }
 
                                 this.getMap().pickItemDrop(pickupPacket, mapitem);
@@ -2120,7 +2120,7 @@ public class Character extends AbstractCharacterObject {
                         this.getCashShop().gainCash(1, nxGain);
 
                         if (YamlConfig.config.server.USE_ANNOUNCE_NX_COUPON_LOOT) {
-                            showHint("You have earned #e#b" + nxGain + " NX#k#n. (" + this.getCashShop().getCash(1) + " NX)", 300);
+                            showHint("You have earned #e#b" + nxGain + " NX#k#n. (" + this.getCashShop().getCash(CashShop.NX_CREDIT) + " NX)", 300);
                         }
                     } else if (applyConsumeOnPickup(mItem.getItemId())) {
                     } else if (InventoryManipulator.addFromDrop(client, mItem, true)) {

--- a/src/main/java/net/packet/ByteBufInPacket.java
+++ b/src/main/java/net/packet/ByteBufInPacket.java
@@ -83,6 +83,11 @@ public class ByteBufInPacket implements InPacket {
     }
 
     @Override
+    public boolean equals(Object o) {
+        return o instanceof ByteBufInPacket other && byteBuf.equals(other.byteBuf);
+    }
+
+    @Override
     public String toString() {
         final int readerIndex = byteBuf.readerIndex();
         byteBuf.markReaderIndex();

--- a/src/main/java/net/packet/ByteBufOutPacket.java
+++ b/src/main/java/net/packet/ByteBufOutPacket.java
@@ -91,4 +91,9 @@ public class ByteBufOutPacket implements OutPacket {
     public void skip(int numberOfBytes) {
         writeBytes(new byte[numberOfBytes]);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof ByteBufOutPacket other && byteBuf.equals(other.byteBuf);
+    }
 }

--- a/src/main/java/net/server/channel/handlers/CashOperationHandler.java
+++ b/src/main/java/net/server/channel/handlers/CashOperationHandler.java
@@ -116,7 +116,7 @@ public final class CashOperationHandler extends AbstractPacketHandler {
                     CashItem cItem = CashItemFactory.getItem(p.readInt());
                     Map<String, String> recipient = Character.getCharacterFromDatabase(p.readString());
                     String message = p.readString();
-                    if (!canBuy(chr, cItem, cs.getCash(4)) || message.length() < 1 || message.length() > 73) {
+                    if (!canBuy(chr, cItem, cs.getCash(CashShop.NX_PREPAID)) || message.isEmpty() || message.length() > 73) {
                         c.enableCSActions();
                         return;
                     }
@@ -405,7 +405,7 @@ public final class CashOperationHandler extends AbstractPacketHandler {
                     c.sendPacket(PacketCreator.showCash(c.getPlayer()));
                 } else if (action == 0x2E) { //name change
                     CashItem cItem = CashItemFactory.getItem(p.readInt());
-                    if (cItem == null || !canBuy(chr, cItem, cs.getCash(4))) {
+                    if (cItem == null || !canBuy(chr, cItem, cs.getCash(CashShop.NX_PREPAID))) {
                         c.sendPacket(PacketCreator.showCashShopMessage((byte) 0));
                         c.enableCSActions();
                         return;
@@ -434,7 +434,7 @@ public final class CashOperationHandler extends AbstractPacketHandler {
                     c.enableCSActions();
                 } else if (action == 0x31) { //world transfer
                     CashItem cItem = CashItemFactory.getItem(p.readInt());
-                    if (cItem == null || !canBuy(chr, cItem, cs.getCash(4))) {
+                    if (cItem == null || !canBuy(chr, cItem, cs.getCash(CashShop.NX_PREPAID))) {
                         c.sendPacket(PacketCreator.showCashShopMessage((byte) 0));
                         c.enableCSActions();
                         return;

--- a/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
+++ b/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
@@ -24,26 +24,33 @@ import client.inventory.Item;
 import net.AbstractPacketHandler;
 import net.packet.InPacket;
 import server.CashShop;
+import server.CashShop.CashShopSurpriseResult;
 import tools.PacketCreator;
-import tools.Pair;
+
+import java.util.Optional;
 
 /**
  * @author RonanLana
+ * @author Ponk
  */
 public class CashShopSurpriseHandler extends AbstractPacketHandler {
+
     @Override
     public final void handlePacket(InPacket p, Client c) {
         CashShop cs = c.getPlayer().getCashShop();
-
-        if (cs.isOpened()) {
-            Pair<Item, Item> cssResult = cs.openCashShopSurprise();
-
-            if (cssResult != null) {
-                Item cssItem = cssResult.getLeft(), cssBox = cssResult.getRight();
-                c.sendPacket(PacketCreator.onCashGachaponOpenSuccess(c.getAccID(), cssBox.getCashId(), cssBox.getQuantity(), cssItem, cssItem.getItemId(), cssItem.getQuantity(), true));
-            } else {
-                c.sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
-            }
+        if (!cs.isOpened()) {
+            return;
         }
+
+        Optional<CashShopSurpriseResult> result = cs.openCashShopSurprise();
+        if (result.isEmpty()) {
+            c.sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
+            return;
+        }
+
+        Item usedCashShopSurprise = result.get().usedCashShopSurprise();
+        Item reward = result.get().reward();
+        c.sendPacket(PacketCreator.onCashGachaponOpenSuccess(c.getAccID(), usedCashShopSurprise.getCashId(),
+                usedCashShopSurprise.getQuantity(), reward, reward.getItemId(), reward.getQuantity(), true));
     }
 }

--- a/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
+++ b/src/main/java/net/server/channel/handlers/CashShopSurpriseHandler.java
@@ -42,7 +42,8 @@ public class CashShopSurpriseHandler extends AbstractPacketHandler {
             return;
         }
 
-        Optional<CashShopSurpriseResult> result = cs.openCashShopSurprise();
+        long cashId = p.readLong();
+        Optional<CashShopSurpriseResult> result = cs.openCashShopSurprise(cashId);
         if (result.isEmpty()) {
             c.sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
             return;

--- a/src/main/java/net/server/channel/handlers/MTSHandler.java
+++ b/src/main/java/net/server/channel/handlers/MTSHandler.java
@@ -35,6 +35,7 @@ import net.server.Server;
 import net.server.channel.Channel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import server.CashShop;
 import server.ItemInformationProvider;
 import server.MTSItemInfo;
 import tools.DatabaseConnection;
@@ -402,7 +403,7 @@ public final class MTSHandler extends AbstractPacketHandler {
                     ResultSet rs = ps.executeQuery();
                     if (rs.next()) {
                         int price = rs.getInt("price") + 100 + (int) (rs.getInt("price") * 0.1); // taxes
-                        if (c.getPlayer().getCashShop().getCash(4) >= price) { // FIX
+                        if (c.getPlayer().getCashShop().getCash(CashShop.NX_PREPAID) >= price) { // FIX
                             boolean alwaysnull = true;
                             for (Channel cserv : Server.getInstance().getAllChannels()) {
                                 Character victim = cserv.getPlayerStorage().getCharacterById(rs.getInt("seller"));
@@ -459,11 +460,11 @@ public final class MTSHandler extends AbstractPacketHandler {
                     ResultSet rs = ps.executeQuery();
                     if (rs.next()) {
                         int price = rs.getInt("price") + 100 + (int) (rs.getInt("price") * 0.1);
-                        if (c.getPlayer().getCashShop().getCash(4) >= price) {
+                        if (c.getPlayer().getCashShop().getCash(CashShop.NX_PREPAID) >= price) {
                             for (Channel cserv : Server.getInstance().getAllChannels()) {
                                 Character victim = cserv.getPlayerStorage().getCharacterById(rs.getInt("seller"));
                                 if (victim != null) {
-                                    victim.getCashShop().gainCash(4, rs.getInt("price"));
+                                    victim.getCashShop().gainCash(CashShop.NX_PREPAID, rs.getInt("price"));
                                 } else {
                                     try (PreparedStatement pse = con.prepareStatement("SELECT accountid FROM characters WHERE id = ?")) {
                                         pse.setInt(1, rs.getInt("seller"));

--- a/src/main/java/tools/PacketCreator.java
+++ b/src/main/java/tools/PacketCreator.java
@@ -77,6 +77,7 @@ import net.server.world.Party;
 import net.server.world.PartyCharacter;
 import net.server.world.PartyOperation;
 import net.server.world.World;
+import server.CashShop;
 import server.CashShop.CashItem;
 import server.CashShop.CashItemFactory;
 import server.CashShop.SpecialCashItem;
@@ -5580,8 +5581,8 @@ public class PacketCreator {
 
     public static Packet showMTSCash(Character chr) {
         final OutPacket p = OutPacket.create(SendOpcode.MTS_OPERATION2);
-        p.writeInt(chr.getCashShop().getCash(4));
-        p.writeInt(chr.getCashShop().getCash(2));
+        p.writeInt(chr.getCashShop().getCash(CashShop.NX_PREPAID));
+        p.writeInt(chr.getCashShop().getCash(CashShop.MAPLE_POINT));
         return p;
     }
 
@@ -5689,9 +5690,9 @@ public class PacketCreator {
 
     public static Packet showCash(Character mc) {
         final OutPacket p = OutPacket.create(SendOpcode.QUERY_CASH_RESULT);
-        p.writeInt(mc.getCashShop().getCash(1));
-        p.writeInt(mc.getCashShop().getCash(2));
-        p.writeInt(mc.getCashShop().getCash(4));
+        p.writeInt(mc.getCashShop().getCash(CashShop.NX_CREDIT));
+        p.writeInt(mc.getCashShop().getCash(CashShop.MAPLE_POINT));
+        p.writeInt(mc.getCashShop().getCash(CashShop.NX_PREPAID));
         return p;
     }
 

--- a/src/main/java/tools/PacketCreator.java
+++ b/src/main/java/tools/PacketCreator.java
@@ -6480,14 +6480,15 @@ public class PacketCreator {
         return p;
     }
 
-    public static Packet onCashGachaponOpenSuccess(int accountid, long sn, int remainingBoxes, Item item, int itemid, int nSelectedItemCount, boolean bJackpot) {
+    public static Packet onCashGachaponOpenSuccess(int accountid, long boxCashId, int remainingBoxes, Item reward,
+                                                   int rewardItemId, int rewardQuantity, boolean bJackpot) {
         OutPacket p = OutPacket.create(SendOpcode.CASHSHOP_CASH_ITEM_GACHAPON_RESULT);
         p.writeByte(0xE5);   // subopcode thanks to Ubaware
-        p.writeLong(sn);// sn of the box used
+        p.writeLong(boxCashId);
         p.writeInt(remainingBoxes);
-        addCashItemInformation(p, item, accountid);
-        p.writeInt(itemid);// the itemid of the liSN?
-        p.writeByte(nSelectedItemCount);// the total count now? o.O
+        addCashItemInformation(p, reward, accountid);
+        p.writeInt(rewardItemId);
+        p.writeByte(rewardQuantity); // nSelectedItemCount
         p.writeBool(bJackpot);// "CashGachaponJackpot"
         return p;
     }

--- a/src/test/java/net/packet/ByteBufInPacketTest.java
+++ b/src/test/java/net/packet/ByteBufInPacketTest.java
@@ -235,4 +235,12 @@ class ByteBufInPacketTest {
 
         assertEquals(initial.length(), afterReadingOpcode.length());
     }
+
+    @Test
+    void equalsShouldCompareBytes() {
+        ByteBufInPacket packet1 = new ByteBufInPacket(Unpooled.wrappedBuffer(new byte[]{ 11, 22, 33, 44 }));
+        ByteBufInPacket packet2 = new ByteBufInPacket(Unpooled.wrappedBuffer(new byte[]{ 11, 22, 33, 44 }));
+
+        assertEquals(packet1, packet2);
+    }
 }

--- a/src/test/java/net/packet/ByteBufOutPacketTest.java
+++ b/src/test/java/net/packet/ByteBufOutPacketTest.java
@@ -203,4 +203,14 @@ class ByteBufOutPacketTest {
         assertEquals(0, wrapped.readByte());
         assertEquals(secondWrittenByte, wrapped.readByte());
     }
+
+    @Test
+    void equalsShouldCompareBytes() {
+        ByteBufOutPacket packet1 = new ByteBufOutPacket();
+        packet1.writeBytes(new byte[] { 55, 66, 77, 88 });
+        ByteBufOutPacket packet2 = new ByteBufOutPacket();
+        packet2.writeBytes(new byte[] { 55, 66, 77, 88 });
+
+        assertEquals(packet1, packet2);
+    }
 }

--- a/src/test/java/net/server/channel/handlers/CashShopSurpriseHandlerTest.java
+++ b/src/test/java/net/server/channel/handlers/CashShopSurpriseHandlerTest.java
@@ -2,6 +2,7 @@ package net.server.channel.handlers;
 
 import client.inventory.Item;
 import constants.id.ItemId;
+import net.packet.InPacket;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,6 +16,7 @@ import tools.PacketCreator;
 
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,21 +33,25 @@ class CashShopSurpriseHandlerTest extends HandlerTest {
         when(chr.getCashShop()).thenReturn(cashShop);
     }
 
+    private InPacket useCashShopSurprisePacket(long cashId) {
+        return Packets.buildInPacket(out -> out.writeLong(cashId));
+    }
+
     @Test
     void shouldDoNothingWhenCsIsNotOpened() {
         when(cashShop.isOpened()).thenReturn(false);
 
-        handler.handlePacket(Packets.emptyInPacket(), client);
+        handler.handlePacket(useCashShopSurprisePacket(123), client);
 
-        verify(cashShop, never()).openCashShopSurprise();
+        verify(cashShop, never()).openCashShopSurprise(anyLong());
     }
 
     @Test
     void shouldSendFailurePacketWhenFailToOpen() {
         when(cashShop.isOpened()).thenReturn(true);
-        when(cashShop.openCashShopSurprise()).thenReturn(Optional.empty());
+        when(cashShop.openCashShopSurprise(anyLong())).thenReturn(Optional.empty());
 
-        handler.handlePacket(Packets.emptyInPacket(), client);
+        handler.handlePacket(useCashShopSurprisePacket(456), client);
 
         verify(client).sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
     }
@@ -55,10 +61,10 @@ class CashShopSurpriseHandlerTest extends HandlerTest {
         when(cashShop.isOpened()).thenReturn(true);
         Item cashShopSurprise = Items.itemWithQuantity(ItemId.CASH_SHOP_SURPRISE, 3);
         Item reward = Items.itemWithQuantity(5000012, 1);
-        when(cashShop.openCashShopSurprise()).thenReturn(Optional.of(new CashShop.CashShopSurpriseResult(
+        when(cashShop.openCashShopSurprise(789)).thenReturn(Optional.of(new CashShop.CashShopSurpriseResult(
                 cashShopSurprise, reward)));
 
-        handler.handlePacket(Packets.emptyInPacket(), client);
+        handler.handlePacket(useCashShopSurprisePacket(789), client);
 
         verify(client).sendPacket(PacketCreator.onCashGachaponOpenSuccess(ACCOUNT_ID, cashShopSurprise.getCashId(), 3,
                 reward, 5000012, 1, true));

--- a/src/test/java/net/server/channel/handlers/CashShopSurpriseHandlerTest.java
+++ b/src/test/java/net/server/channel/handlers/CashShopSurpriseHandlerTest.java
@@ -1,0 +1,66 @@
+package net.server.channel.handlers;
+
+import client.inventory.Item;
+import constants.id.ItemId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import server.CashShop;
+import testutil.HandlerTest;
+import testutil.Items;
+import testutil.Packets;
+import tools.PacketCreator;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CashShopSurpriseHandlerTest extends HandlerTest {
+    private final CashShopSurpriseHandler handler = new CashShopSurpriseHandler();
+
+    @Mock
+    private CashShop cashShop;
+
+    @BeforeEach
+    void prepareCashShop() {
+        when(chr.getCashShop()).thenReturn(cashShop);
+    }
+
+    @Test
+    void shouldDoNothingWhenCsIsNotOpened() {
+        when(cashShop.isOpened()).thenReturn(false);
+
+        handler.handlePacket(Packets.emptyInPacket(), client);
+
+        verify(cashShop, never()).openCashShopSurprise();
+    }
+
+    @Test
+    void shouldSendFailurePacketWhenFailToOpen() {
+        when(cashShop.isOpened()).thenReturn(true);
+        when(cashShop.openCashShopSurprise()).thenReturn(Optional.empty());
+
+        handler.handlePacket(Packets.emptyInPacket(), client);
+
+        verify(client).sendPacket(PacketCreator.onCashItemGachaponOpenFailed());
+    }
+
+    @Test
+    void shouldSendSuccessPacketWhenSuccessfullyOpen() {
+        when(cashShop.isOpened()).thenReturn(true);
+        Item cashShopSurprise = Items.itemWithQuantity(ItemId.CASH_SHOP_SURPRISE, 3);
+        Item reward = Items.itemWithQuantity(5000012, 1);
+        when(cashShop.openCashShopSurprise()).thenReturn(Optional.of(new CashShop.CashShopSurpriseResult(
+                cashShopSurprise, reward)));
+
+        handler.handlePacket(Packets.emptyInPacket(), client);
+
+        verify(client).sendPacket(PacketCreator.onCashGachaponOpenSuccess(ACCOUNT_ID, cashShopSurprise.getCashId(), 3,
+                reward, 5000012, 1, true));
+    }
+}

--- a/src/test/java/testutil/AnyValues.java
+++ b/src/test/java/testutil/AnyValues.java
@@ -8,6 +8,10 @@ public class AnyValues {
         return "string";
     }
 
+    public static short anyShort() {
+        return 4;
+    }
+
     public static DaoException daoException() {
         return new DaoException(string(), new RuntimeException());
     }

--- a/src/test/java/testutil/HandlerTest.java
+++ b/src/test/java/testutil/HandlerTest.java
@@ -1,0 +1,24 @@
+package testutil;
+
+import client.Character;
+import client.Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mock;
+
+import static org.mockito.Mockito.lenient;
+
+public abstract class HandlerTest {
+    protected static final int ACCOUNT_ID = 1702;
+
+    @Mock
+    protected Client client;
+
+    @Mock
+    protected Character chr;
+
+    @BeforeEach
+    void prepareClient() {
+        lenient().when(client.getAccID()).thenReturn(ACCOUNT_ID);
+        lenient().when(client.getPlayer()).thenReturn(chr);
+    }
+}

--- a/src/test/java/testutil/Items.java
+++ b/src/test/java/testutil/Items.java
@@ -1,0 +1,10 @@
+package testutil;
+
+import client.inventory.Item;
+
+public class Items {
+
+    public static Item itemWithQuantity(int itemId, int quantity) {
+        return new Item(itemId, AnyValues.anyShort(), (short) quantity);
+    }
+}

--- a/src/test/java/testutil/Packets.java
+++ b/src/test/java/testutil/Packets.java
@@ -1,0 +1,12 @@
+package testutil;
+
+import io.netty.buffer.Unpooled;
+import net.packet.ByteBufInPacket;
+import net.packet.InPacket;
+
+public class Packets {
+
+    public static InPacket emptyInPacket() {
+        return new ByteBufInPacket(Unpooled.buffer());
+    }
+}

--- a/src/test/java/testutil/Packets.java
+++ b/src/test/java/testutil/Packets.java
@@ -2,11 +2,17 @@ package testutil;
 
 import io.netty.buffer.Unpooled;
 import net.packet.ByteBufInPacket;
+import net.packet.ByteBufOutPacket;
 import net.packet.InPacket;
+import net.packet.OutPacket;
+
+import java.util.function.Consumer;
 
 public class Packets {
 
-    public static InPacket emptyInPacket() {
-        return new ByteBufInPacket(Unpooled.buffer());
+    public static InPacket buildInPacket(Consumer<OutPacket> contentProvider) {
+        OutPacket builderInput = new ByteBufOutPacket();
+        contentProvider.accept(builderInput);
+        return new ByteBufInPacket(Unpooled.wrappedBuffer(builderInput.getBytes()));
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
- #242 fixed Cash shop surprise count being properly updated on usage. What it didn't fix was removing the item once the last Cash shop surprise is used. This PR fixes that.
- Minor refactoring of Cash shop and the relevant handler to improve readability
- Tests for CashShopSurpriseHandler. 
- No tests for Cash shop due to it not being testable due to DB queries in its constructor. Have to revisit this once the database has been reworked.
- Use the selected Cash shop surprise instead of always the first one.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [x] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
