### PR TITLE
NPC (Vard): Fix "Plastic Surgery" option

### DIFF
--- a/scripts/npc/2100008.js
+++ b/scripts/npc/2100008.js
@@ -58,8 +58,8 @@ function action(mode, type, selection) {
                     }
                 }
                 if (cm.getChar().getGender() == 1) {
-                    for (var i = 0; i < fface.length; i++) {
-                        pushIfItemExists(facenew, fface[i] + cm.getChar().getFace()
+                    for (var i = 0; i < fface_v.length; i++) {
+                        pushIfItemExists(facenew, fface_v[i] + cm.getChar().getFace()
                             % 1000 - (cm.getChar().getFace()
                                 % 100));
                     }


### PR DESCRIPTION
## Description

The "Plastic Surgery" option of Vard doesn't work.

### Solution

Correct typos for variable `fface_v` in the NPC script.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots

None