### PR TITLE
chaos scroll fix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -345,7 +345,7 @@ server:
     USE_ENHANCED_CRAFTING: false     #Apply chaos scroll on every equip crafted.
     SCROLL_CHANCE_ROLLS: 1         #Number of rolls for success on a scroll, set 1 for default.
     CHSCROLL_STAT_RATE: 1               #Number of rolls of stat upgrade on a successfully applied chaos scroll, set 1 for default.
-    CHSCROLL_STAT_RANGE: 6              #Stat upgrade range (-N, N) on chaos scrolls.
+    CHSCROLL_STAT_RANGE: 5              #Stat upgrade range (-N, N) on chaos scrolls.
 
     #Beginner Skills Configuration
     USE_ULTRA_NIMBLE_FEET: false     #Massive speed & jump upgrade.

--- a/src/main/java/tools/Randomizer.java
+++ b/src/main/java/tools/Randomizer.java
@@ -35,6 +35,6 @@ public class Randomizer {
     }
 
     public static int rand(final int lbound, final int ubound) {
-        return (int) ((rand.nextDouble() * (ubound - lbound + 1)) + lbound);
+        return ((int) (rand.nextDouble() * (ubound - lbound + 1))) + lbound;
     }
 }

--- a/src/test/java/tools/RandomizerTest.java
+++ b/src/test/java/tools/RandomizerTest.java
@@ -1,0 +1,37 @@
+package tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RandomizerTest {
+
+    @Test
+    void randShouldIncludeEntireRange() {
+        Map<Integer, Integer> rands = new HashMap<>();
+
+        final int rounds = 100_000;
+        for (int i = 0; i < rounds; i++) {
+            int randomValue = Randomizer.rand(-5, 5);
+            rands.compute(randomValue, (k, v) -> v == null ? 0 : v + 1);
+        }
+
+        assertFalse(rands.containsKey(-6));
+        assertTrue(rands.containsKey(-5));
+        assertTrue(rands.containsKey(-4));
+        assertTrue(rands.containsKey(-3));
+        assertTrue(rands.containsKey(-2));
+        assertTrue(rands.containsKey(-1));
+        assertTrue(rands.containsKey(0));
+        assertTrue(rands.containsKey(1));
+        assertTrue(rands.containsKey(2));
+        assertTrue(rands.containsKey(3));
+        assertTrue(rands.containsKey(4));
+        assertTrue(rands.containsKey(5));
+        assertFalse(rands.containsKey(6));
+    }
+}


### PR DESCRIPTION
## Description
The intention of the rand method (which is used to determine stat changes when using chaos scrolls) is to return a pseudorandom uniformly distributed int between lbound and ubound (both inclusive). The previous implementation did not work as intended when the lower bound was negative since java rounds up instead of down when casting a negative double to an int. As a result, +0 was twice as likely as any other result, and -lbound was only possible when nextDouble returned exactly 0. Adding the lower bound after the cast rather than before fixes this since the number being cast to an int will always be positive.

Also changed the CHSCROLL_STAT_RANGE from 6 to 5 in the config to be consistent with gms.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
