### PR TITLE
Refactored the command classes that adds stats

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -162,7 +162,7 @@ server:
     DB_URL_FORMAT: "jdbc:mysql://%s:3306/cosmic" # If the docker ENV for DB_HOST is anything but "db", this string format should be changed from 3306 to 3307 (or whichever port it was changed to in docker) 
     DB_HOST: "localhost" 
     DB_USER: "root"
-    DB_PASS: ""
+    DB_PASS: "root"
     INIT_CONNECTION_POOL_TIMEOUT: 90    # Seconds
 
     #Login Configuration
@@ -178,8 +178,8 @@ server:
     COUPON_INTERVAL: 3600000            #60 minutes, 3600000.
     UPDATE_INTERVAL: 777                #Dictates the frequency on which the "centralized server time" is updated.
 
-    ENABLE_PIC: true               #Pick true/false to enable or disable Pic. Delete character requires PIC available.
-    ENABLE_PIN: true               #Pick true/false to enable or disable Pin.
+    ENABLE_PIC: false               #Pick true/false to enable or disable Pic. Delete character requires PIC available.
+    ENABLE_PIN: false               #Pick true/false to enable or disable Pin.
 
     BYPASS_PIC_EXPIRATION: 20           #Enables PIC bypass, which will remain active for that account by that client machine for N minutes. Set 0 to disable.
     BYPASS_PIN_EXPIRATION: 15           #Enables PIN bypass, which will remain active for that account by that client machine for N minutes. Set 0 to disable.
@@ -205,40 +205,40 @@ server:
     SHUTDOWNHOOK: true
 
     #Server Flags
-    USE_CUSTOM_KEYSET: false             #Enables auto-setup of the HeavenMS's custom keybindings when creating characters.
+    USE_CUSTOM_KEYSET: false            #Enables auto-setup of the HeavenMS's custom keybindings when creating characters.
     USE_DEBUG: false                    #Will enable some text prints on the client, oriented for debugging purposes.
     USE_DEBUG_SHOW_INFO_EQPEXP: false   #Prints on the cmd all equip exp gain info.
     USE_DEBUG_SHOW_RCVD_PACKET: false   #Prints on the cmd all received packet ids.
     USE_DEBUG_SHOW_RCVD_MVLIFE: false   #Prints on the cmd all received move life content.
     USE_DEBUG_SHOW_PACKET: false
     USE_SUPPLY_RATE_COUPONS: true       #Allows rate coupons to be sold through the Cash Shop.
-    USE_IP_VALIDATION: false             #Enables IP checking when logging in.
+    USE_IP_VALIDATION: false            #Enables IP checking when logging in.
     USE_CHARACTER_ACCOUNT_CHECK: false  #Enables one-character-per-account check when logging in. This might be resource intensive.
 
     USE_MAXRANGE: true                  #Will send and receive packets from all events on a map, rather than those of only view range.
     USE_MAXRANGE_ECHO_OF_HERO: true
-    USE_MTS: false
+    USE_MTS: true
     USE_CPQ: true                       #Renders the CPQ available or not.
-    USE_AUTOHIDE_GM: true              #When enabled, GMs are automatically hidden when joining. Thanks to Steven Deblois (steven1152).
-    USE_FIXED_RATIO_HPMP_UPDATE: false   #Enables the HeavenMS-builtin HPMP update based on the current pool to max pool ratio.
+    USE_AUTOHIDE_GM: true               #When enabled, GMs are automatically hidden when joining. Thanks to Steven Deblois (steven1152).
+    USE_FIXED_RATIO_HPMP_UPDATE: false  #Enables the HeavenMS-builtin HPMP update based on the current pool to max pool ratio.
     USE_FAMILY_SYSTEM: true
     USE_DUEY: true
     USE_RANDOMIZE_HPMP_GAIN: true       #Enables randomizing on MaxHP/MaxMP gains and INT accounting for the MaxMP gain on level up.
     USE_STORAGE_ITEM_SORT: true         #Enables storage "Arrange Items" feature.
     USE_ITEM_SORT: true                 #Enables inventory "Item Sort/Merge" feature.
     USE_ITEM_SORT_BY_NAME: false        #Item sorting based on name rather than id.
-    USE_PARTY_FOR_STARTERS: false        #Players level 10 or below can create/invite other players on the given level range.
-    USE_AUTOASSIGN_STARTERS_AP: true   #Beginners level 10 or below have their AP autoassigned (they can't choose to levelup a stat). Set true ONLY if the localhost doesn't support AP assigning for beginners level 10 or below.
+    USE_PARTY_FOR_STARTERS: false       #Players level 10 or below can create/invite other players on the given level range.
+    USE_AUTOASSIGN_STARTERS_AP: true    #Beginners level 10 or below have their AP autoassigned (they can't choose to levelup a stat). Set true ONLY if the localhost doesn't support AP assigning for beginners level 10 or below.
     USE_AUTOASSIGN_SECONDARY_CAP: true  #Prevents AP autoassign from spending on secondary stats after the player class' cap (defined on the autoassign handler) has been reached.
-    USE_STARTING_AP_4: false             #Use early-GMS 4/4/4/4 starting stats. To overcome AP shortage, this gives 4AP/5AP at 1st/2nd job advancements.
+    USE_STARTING_AP_4: false            #Use early-GMS 4/4/4/4 starting stats. To overcome AP shortage, this gives 4AP/5AP at 1st/2nd job advancements.
     USE_AUTOBAN: false                  #Commands the server to detect infractors automatically.
     USE_AUTOBAN_LOG: true               #Log autoban related messages. Still logs even with USE_AUTOBAN disabled.
     USE_EXP_GAIN_LOG: false #Logs characters exp gains; logs world rate & coupon exp, total gained exp, and current exp, level can be calculated from "ExpTable".
     USE_AUTOSAVE: true                  #Enables server autosaving feature (saves characters to DB each 1 hour).
-    USE_SERVER_AUTOASSIGNER: false       #HeavenMS-builtin autoassigner, uses algorithm based on distributing AP accordingly with required secondary stat on equipments.
+    USE_SERVER_AUTOASSIGNER: false      #HeavenMS-builtin autoassigner, uses algorithm based on distributing AP accordingly with required secondary stat on equipments.
     USE_REFRESH_RANK_MOVE: true
     USE_ENFORCE_ADMIN_ACCOUNT: false    #Forces accounts having GM characters to be treated as a "GM account" by the client (localhost). Some of the GM account perks is the ability to FLY, but unable to TRADE.
-    USE_ENFORCE_NOVICE_EXPRATE: false    #Hardsets experience rate 1x for beginners level 10 or under. Ideal for roaming on novice areas without caring too much about losing some stats.
+    USE_ENFORCE_NOVICE_EXPRATE: false   #Hardsets experience rate 1x for beginners level 10 or under. Ideal for roaming on novice areas without caring too much about losing some stats.
     USE_ENFORCE_HPMP_SWAP: false        #Forces players to reuse stats (via AP Resetting) located on HP/MP pool only inside the HP/MP stats.
     USE_ENFORCE_MOB_LEVEL_RANGE: true   #Players N levels below the killed mob will gain no experience from defeating it.
     USE_ENFORCE_JOB_LEVEL_RANGE: false  #Caps the player level on the minimum required to advance their current jobs.

--- a/src/main/java/client/command/CommandsExecutor.java
+++ b/src/main/java/client/command/CommandsExecutor.java
@@ -24,6 +24,10 @@
 package client.command;
 
 import client.Client;
+import client.command.commands.gm0.AddDexCommand;
+import client.command.commands.gm0.AddIntCommand;
+import client.command.commands.gm0.AddLukCommand;
+import client.command.commands.gm0.AddStrCommand;
 import client.command.commands.gm0.ChangeLanguageCommand;
 import client.command.commands.gm0.DisposeCommand;
 import client.command.commands.gm0.DropLimitCommand;
@@ -42,10 +46,8 @@ import client.command.commands.gm0.ReadPointsCommand;
 import client.command.commands.gm0.ReportBugCommand;
 import client.command.commands.gm0.ShowRatesCommand;
 import client.command.commands.gm0.StaffCommand;
-import client.command.commands.gm0.StatDexCommand;
 import client.command.commands.gm0.StatIntCommand;
 import client.command.commands.gm0.StatLukCommand;
-import client.command.commands.gm0.StatStrCommand;
 import client.command.commands.gm0.TimeCommand;
 import client.command.commands.gm0.ToggleExpCommand;
 import client.command.commands.gm0.UptimeCommand;
@@ -340,6 +342,10 @@ public class CommandsExecutor {
     private void registerLv0Commands() {
         levelCommandsCursor = new Pair<>(new ArrayList<String>(), new ArrayList<String>());
 
+        addCommand("dex", AddDexCommand.class);
+        addCommand("int", AddIntCommand.class);
+        addCommand("luk", AddLukCommand.class);
+        addCommand("str", AddStrCommand.class);
         addCommand(new String[]{"help", "commands"}, HelpCommand.class);
         addCommand("droplimit", DropLimitCommand.class);
         addCommand("time", TimeCommand.class);
@@ -358,10 +364,10 @@ public class CommandsExecutor {
         addCommand("joinevent", JoinEventCommand.class);
         addCommand("leaveevent", LeaveEventCommand.class);
         addCommand("ranks", RanksCommand.class);
-        addCommand("str", StatStrCommand.class);
-        addCommand("dex", StatDexCommand.class);
-        addCommand("int", StatIntCommand.class);
-        addCommand("luk", StatLukCommand.class);
+        //addCommand("str", StatStrCommand.class);
+        //addCommand("dex", StatDexCommand.class);
+        //addCommand("int", StatIntCommand.class);
+        //addCommand("luk", StatLukCommand.class);
         addCommand("enableauth", EnableAuthCommand.class);
         addCommand("toggleexp", ToggleExpCommand.class);
         addCommand("mylawn", MapOwnerClaimCommand.class);

--- a/src/main/java/client/command/StatCommand.java
+++ b/src/main/java/client/command/StatCommand.java
@@ -1,0 +1,52 @@
+package client.command;
+
+import client.Character;
+import client.Client;
+import config.YamlConfig;
+
+public abstract class StatCommand extends Command {
+
+    protected enum Stat {DEX, INT, LUK, STR}
+    protected Stat stat;
+
+    public void execute(Client c, String[] params) {
+        AssignStat(c, params, stat);
+    }
+
+    private void AssignStat(Client client, String[] params, Stat stat)
+    {
+        Character character = client.getPlayer();
+        if (params.length < 1) {
+            character.dropMessage("Enter an amount of AP you want to assign.");
+        }
+        try {
+            int amount = Integer.parseInt(params[0]);
+            int remainingAp = character.getRemainingAp();
+            if (isValidAmount(amount, remainingAp)) {
+                switch (stat) {
+                    case DEX -> character.assignDex(amount);
+                    case INT -> character.assignInt(amount);
+                    case LUK -> character.assignLuk(amount);
+                    case STR -> character.assignStr(amount);
+                    default -> throw new IllegalStateException("Unexpected value: " + stat);
+                }
+                character.dropMessage("Assigned " + amount + " into " + stat);
+            }
+            else {
+                character.dropMessage("You have entered an invalid amount of AP.");
+            }
+        }
+        catch (NumberFormatException ex) {
+            character.dropMessage("Enter a valid number!");
+        }
+    }
+    private boolean isValidAmount(int amount, int remainingAp) {
+        return amount > 0
+                && amount <= remainingAp
+                && amount <= YamlConfig.config.server.MAX_AP;
+    }
+
+    protected void setStat(Stat stat) {
+        this.stat = stat;
+    }
+}

--- a/src/main/java/client/command/commands/gm0/AddDexCommand.java
+++ b/src/main/java/client/command/commands/gm0/AddDexCommand.java
@@ -1,0 +1,17 @@
+package client.command.commands.gm0;
+
+import client.Client;
+import client.command.StatCommand;
+
+public class AddDexCommand extends StatCommand {
+
+    {
+        setStat(Stat.DEX);
+        setDescription("Assigns AP into " + stat);
+    }
+
+    @Override
+    public void execute(Client client, String[] params) {
+        super.execute(client, params);
+    }
+}

--- a/src/main/java/client/command/commands/gm0/AddIntCommand.java
+++ b/src/main/java/client/command/commands/gm0/AddIntCommand.java
@@ -1,0 +1,17 @@
+package client.command.commands.gm0;
+
+import client.Client;
+import client.command.StatCommand;
+
+public class AddIntCommand extends StatCommand {
+
+    {
+        setStat(Stat.INT);
+        setDescription("Assigns AP into " + stat);
+    }
+
+    @Override
+    public void execute(Client client, String[] params) {
+        super.execute(client, params);
+    }
+}

--- a/src/main/java/client/command/commands/gm0/AddLukCommand.java
+++ b/src/main/java/client/command/commands/gm0/AddLukCommand.java
@@ -1,0 +1,17 @@
+package client.command.commands.gm0;
+
+import client.Client;
+import client.command.StatCommand;
+
+public class AddLukCommand extends StatCommand {
+
+    {
+        setStat(Stat.LUK);
+        setDescription("Assigns AP into " + stat);
+    }
+
+    @Override
+    public void execute(Client client, String[] params) {
+        super.execute(client, params);
+    }
+}

--- a/src/main/java/client/command/commands/gm0/AddStrCommand.java
+++ b/src/main/java/client/command/commands/gm0/AddStrCommand.java
@@ -1,0 +1,17 @@
+package client.command.commands.gm0;
+
+import client.Client;
+import client.command.StatCommand;
+
+public class AddStrCommand extends StatCommand {
+
+    {
+        setStat(Stat.STR);
+        setDescription("Assigns AP into " + stat);
+    }
+
+    @Override
+    public void execute(Client client, String[] params) {
+        super.execute(client, params);
+    }
+}


### PR DESCRIPTION
## Description
1. The commands to assign stats LUK, STR, DEX and INT all use the same code, basically copy/pasted 4 times. I have refactored that code into one class and made it reuseable.
2. Changed the logic to only add the amount of AP that is actually typed to prevent the player from adding too much AP by mistake. For example: 
- Player A has 100 AP.
- Player A wants to add 5 AP into INT. 
- Player A has fat fingers and hits both '5' and '6' and accidentally adds 56 AP.
- Player A has network issues and accidentally taps '5' two times and adds 55 AP.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
