### PR TITLE
Fix staggered exploding mesos

### DIFF
--- a/src/main/java/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/src/main/java/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -112,6 +112,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
+    private static final int EXPLODED_MESO_SPREAD_DELAY = 100;
+    private static final int EXPLODED_MESO_MAX_DELAY = 1000;
 
     public static class AttackInfo {
 
@@ -936,7 +938,7 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
     }
 
     private void removeExplodedMesos(MapleMap map, AttackInfo attack) {
-        short delay = attack.attackDelay;
+        int index = 0;
         for (Integer mesoId : attack.explodedMesos) {
             MapObject mapobject = map.getMapObject(mesoId);
             if (!(mapobject instanceof MapItem mapItem)) {
@@ -951,11 +953,12 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                 if (mapItem.isPickedUp()) {
                     return;
                 }
-                map.pickItemDrop(PacketCreator.removeExplodedMesoFromMap(mapItem.getObjectId(), delay), mapItem);
+                int delay = attack.attackDelay + (index++ % 5) * EXPLODED_MESO_SPREAD_DELAY;
+                delay = Math.min(delay, EXPLODED_MESO_MAX_DELAY);
+                map.pickItemDrop(PacketCreator.removeExplodedMesoFromMap(mapItem.getObjectId(), (short) delay), mapItem);
             } finally {
                 mapItem.unlockItem();
             }
-            delay += 100;
         }
     }
 }


### PR DESCRIPTION
## Description
Adjust delay of exploded mesos to align with vanilla. Effectively limits the animation to max 1 second and spread it across bunches of +0, +100, +200, +300 and +400 ms.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
