### PR TITLE
Fix global drops thread issue

### DIFF
--- a/src/main/java/server/life/MonsterInformationProvider.java
+++ b/src/main/java/server/life/MonsterInformationProvider.java
@@ -58,7 +58,7 @@ public class MonsterInformationProvider {
 
     private final Map<Integer, List<MonsterDropEntry>> drops = new HashMap<>();
     private final List<MonsterGlobalDropEntry> globaldrops = new ArrayList<>();
-    private final Map<Integer, List<MonsterGlobalDropEntry>> continentdrops = new HashMap<>();
+    private final Map<Integer, List<MonsterGlobalDropEntry>> continentDrops = new HashMap<>();
 
     private final Map<Integer, List<Integer>> dropsChancePool = new HashMap<>();    // thanks to ronan
     private final Set<Integer> hasNoMultiEquipDrops = new HashSet<>();
@@ -76,23 +76,15 @@ public class MonsterInformationProvider {
         retrieveGlobal();
     }
 
-    public final List<MonsterGlobalDropEntry> getRelevantGlobalDrops(int mapid) {
-        int continentid = mapid / 100000000;
+    public final List<MonsterGlobalDropEntry> getRelevantGlobalDrops(int mapId) {
+        final int continentId = mapId / 100000000;
+        return continentDrops.computeIfAbsent(continentId, this::loadContinentDrops);
+    }
 
-        List<MonsterGlobalDropEntry> contiItems = continentdrops.get(continentid);
-        if (contiItems == null) {   // continent separated global drops found thanks to marcuswoon
-            contiItems = new ArrayList<>();
-
-            for (MonsterGlobalDropEntry e : globaldrops) {
-                if (e.continentid < 0 || e.continentid == continentid) {
-                    contiItems.add(e);
-                }
-            }
-
-            continentdrops.put(continentid, contiItems);
-        }
-
-        return contiItems;
+    private List<MonsterGlobalDropEntry> loadContinentDrops(int continentId) {
+        return globaldrops.stream()
+                .filter(dropEntry -> dropEntry.continentid < 0 || dropEntry.continentid == continentId)
+                .toList();
     }
 
     private void retrieveGlobal() {
@@ -291,7 +283,7 @@ public class MonsterInformationProvider {
         extraMultiEquipDrops.clear();
         dropsChancePool.clear();
         globaldrops.clear();
-        continentdrops.clear();
+        continentDrops.clear();
         retrieveGlobal();
     }
 }

--- a/src/main/java/server/maps/MapleMap.java
+++ b/src/main/java/server/maps/MapleMap.java
@@ -751,7 +751,7 @@ public class MapleMap {
         }
 
         final MonsterInformationProvider mi = MonsterInformationProvider.getInstance();
-        final List<MonsterGlobalDropEntry> globalEntry = mi.getRelevantGlobalDrops(this.getId());
+        final List<MonsterGlobalDropEntry> globalEntry = new ArrayList<>(mi.getRelevantGlobalDrops(mapid));
 
         final List<MonsterDropEntry> dropEntry = new ArrayList<>();
         final List<MonsterDropEntry> visibleQuestEntry = new ArrayList<>();


### PR DESCRIPTION
## Description
Fix global drops concurrency issue. The same ArrayList is no longer shuffled on each killed monster. Rather, a new one is instantiated and populated with the global drops. Slightly inefficient but correctness is more important. Will likely revise in the future.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
