### PR TITLE
fix maker monster crystal level calculation

### DIFF
--- a/src/main/java/server/ItemInformationProvider.java
+++ b/src/main/java/server/ItemInformationProvider.java
@@ -2063,7 +2063,7 @@ public class ItemInformationProvider {
                 try (ResultSet rs = ps.executeQuery()) {
                     if (rs.next()) {
                         int dropperid = rs.getInt("dropperid");
-                        itemid = getCrystalForLevel(LifeFactory.getMonsterLevel(dropperid) - 1);
+                        itemid = getCrystalForLevel(LifeFactory.getMonsterLevel(dropperid));
                     }
                 }
             }


### PR DESCRIPTION
## Description
Maker monster crystal level calculation is off by 1 because the level get -1 twice

`itemid = getCrystalForLevel(LifeFactory.getMonsterLevel(dropperid) - 1);`
```
private static int getCrystalForLevel(int level) {
        int range = (level - 1) / 10;

        if (range < 5) {
            return ItemId.BASIC_MONSTER_CRYSTAL_1;
        } else if (range > 11) {
            return ItemId.ADVANCED_MONSTER_CRYSTAL_3;
        } else {
            return switch (range) {
                case 5 -> ItemId.BASIC_MONSTER_CRYSTAL_2;
                case 6 -> ItemId.BASIC_MONSTER_CRYSTAL_3;
                case 7 -> ItemId.INTERMEDIATE_MONSTER_CRYSTAL_1;
                case 8 -> ItemId.INTERMEDIATE_MONSTER_CRYSTAL_2;
                case 9 -> ItemId.INTERMEDIATE_MONSTER_CRYSTAL_3;
                case 10 -> ItemId.ADVANCED_MONSTER_CRYSTAL_1;
                default -> ItemId.ADVANCED_MONSTER_CRYSTAL_2;
            };
        }
    }
```

4260006 - Advanced Monster Crystal 1 - A Monster Crystal that was formed by combining the droppings of monsters on level 101 ~ 110.
4260007 - Advanced Monster Crystal 2 - A Monster Crystal that was formed by combining the droppings of monsters on level 111 ~ 120.

lv 111 item will get Adv Crystal 1
After fix should get Adv Crystal 2

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
