### PR TITLE
Fix mob skills not applying to players

### DIFF
--- a/src/main/java/server/life/MobSkillFactory.java
+++ b/src/main/java/server/life/MobSkillFactory.java
@@ -99,7 +99,7 @@ public class MobSkillFactory {
             long duration = SECONDS.toMillis(DataTool.getInt("time", skillData, 0));
             long cooltime = SECONDS.toMillis(DataTool.getInt("interval", skillData, 0));
             int iprop = DataTool.getInt("prop", skillData, 100);
-            float prop = iprop / 100;
+            float prop = (float)iprop / 100;
             int limit = DataTool.getInt("limit", skillData, 0);
 
             Data ltData = skillData.getChildByPath("lt");


### PR DESCRIPTION
## Description
Mob skills didn't work because of integer division.
`prop` was either `0.0` or `1.0`

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [V] I have performed a self-review of my code
- [V] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
