### PR TITLE
Fix cash medals not displaying correctly to other players.

### DIFF
--- a/src/main/java/tools/PacketCreator.java
+++ b/src/main/java/tools/PacketCreator.java
@@ -303,7 +303,7 @@ public class PacketCreator {
         Map<Short, Integer> myEquip = new LinkedHashMap<>();
         Map<Short, Integer> maskedEquip = new LinkedHashMap<>();
         for (Item item : ii) {
-            short pos = (byte) (item.getPosition() * -1);
+            short pos = (short) (item.getPosition() * -1);
             if (pos < 100 && myEquip.get(pos) == null) {
                 myEquip.put(pos, item.getItemId());
             } else if (pos > 100 && pos != 111) { // don't ask. o.o


### PR DESCRIPTION
….

## Description
In GMSv83, the medal slot is -49, so the cash medal slot should be -149. Since the byte type in Java can't handle this value, simply adjusting it to a short type will resolve the problem.

## Checklist before requesting a review
- [ x] I have performed a self-review of my code
- [ x] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
