### PR TITLE
Fix Aran - Combo Drain to calculate HP recovery based on single mob damage, not total damage.

### DIFF
--- a/src/main/java/net/server/channel/handlers/AbstractDealDamageHandler.java
+++ b/src/main/java/net/server/channel/handlers/AbstractDealDamageHandler.java
@@ -419,11 +419,8 @@ public abstract class AbstractDealDamageHandler extends AbstractPacketHandler {
                             }
                         }
                     } else if (player.getBuffedValue(BuffStat.COMBO_DRAIN) != null) {
-                        Skill skill;
-                        if (player.getBuffedValue(BuffStat.COMBO_DRAIN) != null) {
-                            skill = SkillFactory.getSkill(21100005);
-                            player.addHP(((totDamage * skill.getEffect(player.getSkillLevel(skill)).getX()) / 100));
-                        }
+                        Skill skill = SkillFactory.getSkill(Aran.COMBO_DRAIN);
+                        player.addHP(((totDamageToOneMonster * skill.getEffect(player.getSkillLevel(skill)).getX()) / 100));
                     } else if (job == 412 || job == 422 || job == 1411) {
                         Skill type = SkillFactory.getSkill(player.getJob().getId() == 412 ? 4120005 : (player.getJob().getId() == 1411 ? 14110004 : 4220005));
                         if (player.getSkillLevel(type) > 0) {


### PR DESCRIPTION

## Description
For example, if there are 5 monsters and you deal 1000 damage to each, the first monster is calculated as 1000 * x, but by the second monster, it becomes 2000 * x

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [ x] I have performed a self-review of my code
- [ x] I have tested my changes

## Screenshots
