### PR TITLE
Fix incorrect method usage in NPC script (9120003.js)

### DIFF
--- a/scripts/npc/9120003.js
+++ b/scripts/npc/9120003.js
@@ -46,7 +46,7 @@ function action(mode, type, selection) {
         cm.dispose();
         return;
     }
-    if (cm.getMeso < price) {
+    if (cm.getMeso() < price) {
         cm.sendOk("Please check and see if you have " + price + " mesos to enter this place.");
     } else {
         cm.gainMeso(-price);


### PR DESCRIPTION


## Description
Corrected the condition in NPC script 9120003.js by replacing cm.getMeso < price with cm.getMeso() < price to properly compare mesos against the price.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [V ] I have performed a self-review of my code
- [V ] I have tested my changes
- [X ] I have added unit tests that prove my changes work

## Screenshots
