### PR TITLE
drop rate fixes

### DIFF
--- a/src/main/java/server/maps/MapleMap.java
+++ b/src/main/java/server/maps/MapleMap.java
@@ -668,14 +668,14 @@ public class MapleMap {
             float cardRate = chr.getCardRate(de.itemId);
             int dropChance = (int) Math.min((float) de.chance * chRate * cardRate, Integer.MAX_VALUE);
 
-            if (Randomizer.nextInt(999999) < dropChance) {
+            if (Randomizer.nextInt(1000000) < dropChance) {
                 if (droptype == 3) {
                     pos.x = mobpos + ((d % 2 == 0) ? (40 * ((d + 1) / 2)) : -(40 * (d / 2)));
                 } else {
                     pos.x = mobpos + ((d % 2 == 0) ? (25 * ((d + 1) / 2)) : -(25 * (d / 2)));
                 }
                 if (de.itemId == 0) { // meso
-                    int mesos = Randomizer.nextInt(de.Maximum - de.Minimum) + de.Minimum;
+                    int mesos = Randomizer.nextInt(de.Maximum - de.Minimum + 1) + de.Minimum;
 
                     if (mesos > 0) {
                         if (chr.getBuffedValue(BuffStat.MESOUP) != null) {
@@ -692,7 +692,7 @@ public class MapleMap {
                     if (ItemConstants.getInventoryType(de.itemId) == InventoryType.EQUIP) {
                         idrop = ii.randomizeStats((Equip) ii.getEquipById(de.itemId));
                     } else {
-                        idrop = new Item(de.itemId, (short) 0, (short) (de.Maximum != 1 ? Randomizer.nextInt(de.Maximum - de.Minimum) + de.Minimum : 1));
+                        idrop = new Item(de.itemId, (short) 0, (short) (Randomizer.nextInt(de.Maximum - de.Minimum + 1) + de.Minimum));
                     }
                     spawnDrop(idrop, calcDropPos(pos, mob.getPosition()), mob, chr, droptype, de.questid);
                 }
@@ -710,7 +710,7 @@ public class MapleMap {
         ItemInformationProvider ii = ItemInformationProvider.getInstance();
 
         for (final MonsterGlobalDropEntry de : globalEntry) {
-            if (Randomizer.nextInt(999999) < de.chance) {
+            if (Randomizer.nextInt(1000000) < de.chance) {
                 if (droptype == 3) {
                     pos.x = mobpos + (d % 2 == 0 ? (40 * (d + 1) / 2) : -(40 * (d / 2)));
                 } else {
@@ -720,7 +720,7 @@ public class MapleMap {
                     if (ItemConstants.getInventoryType(de.itemId) == InventoryType.EQUIP) {
                         idrop = ii.randomizeStats((Equip) ii.getEquipById(de.itemId));
                     } else {
-                        idrop = new Item(de.itemId, (short) 0, (short) (de.Maximum != 1 ? Randomizer.nextInt(de.Maximum - de.Minimum) + de.Minimum : 1));
+                        idrop = new Item(de.itemId, (short) 0, (short) (Randomizer.nextInt(de.Maximum - de.Minimum + 1) + de.Minimum));
                     }
                     spawnDrop(idrop, calcDropPos(pos, mob.getPosition()), mob, chr, droptype, de.questid);
                     d++;

--- a/src/test/java/tools/NextIntTest.java
+++ b/src/test/java/tools/NextIntTest.java
@@ -1,0 +1,33 @@
+package tools;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NextIntTest {
+
+    @Test
+    void dropQuantityShouldIncludeEntireRange() {
+        Map<Integer, Integer> rands;
+        final int rounds = 100_000;
+        for (int min = 1; min < 100; min++) {
+            for (int max = min; max < 100; max++) {
+                rands = new HashMap<>();
+                for (int i = 0; i < rounds; i++) {
+                    int randomValue = Randomizer.nextInt(max - min + 1) + min;
+                    rands.compute(randomValue, (k, v) -> v == null ? 0 : v + 1);
+                }
+
+                assertFalse(rands.containsKey(min - 1));
+                for (int i = min; i <= max; i++) {
+                    assertTrue(rands.containsKey(i));
+                }
+                assertFalse(rands.containsKey(max + 1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

The probability was very slightly off when calculating drop chances. The previous code generated a random integer between 0 (inclusive) and 999,999 (exclusive), when both bounds should have been inclusive. This is based on the assumption that a drop chance of 100,000 should correspond to 10%. Previously there were 999,999 possible values that could be generated (all of the integers from 0 to 999,998), and 100,000 of them were less than 100,000 (all of the integers from 0 to 99,999), so since every integer is equally likely to be generated this gave a 100,000 / 999,999 probability of dropping the item, which is very slightly more than 0.1. This difference is small enough to be negligible, which is probably why it wasn't caught. Increasing the upper bound of the randomly generated number by 1 fixes this.

Additionally, the code which determined the quantity of items dropped when the maximum quantity was greater than 1 always gave a number less than the maximum, and didn't work at all if the max and min were equal. Adding 1 to the bound of the randomly generated number fixes this as well, as shown by the unit test. Also removed the de.Maximum != 1 check since this is not necessary with the fix.

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [ x] I have performed a self-review of my code
- [x ] I have tested my changes
- [x ] I have added unit tests that prove my changes work
