### PR TITLE
Prevent potential memory buildup by cancelling removeAfter task

### DIFF
--- a/src/main/java/server/life/Monster.java
+++ b/src/main/java/server/life/Monster.java
@@ -905,6 +905,7 @@ public class Monster extends AbstractLoadedLife {
                 eim.friendlyKilled(this, hasKiller);
             }
         }
+        getMap().dismissRemoveAfter(this); // Cancel removeAfter to prevent 9400547 from scheduling 90000s tasks, which may cause memory leak-like buildup
     }
 
     private synchronized void processMonsterKilled(boolean hasKiller) {


### PR DESCRIPTION
Call `getMap().dismissRemoveAfter(this)` to cancel the scheduled `removeAfter` task. This prevents task `9400547` from repeatedly scheduling long-running (`90000s`) operations, which could lead to memory leak-like accumulation over time.

## Description

This change introduces a call to `getMap().dismissRemoveAfter(this)` to proactively cancel a previously scheduled `removeAfter` task. Without this, task `9400547` may continuously reschedule operations with a long delay (90000 seconds), leading to memory pressure or leaks. This fix ensures proper lifecycle management and prevents such unbounded task accumulation.

## Checklist before requesting a review

<!-- Mark with "x" inside the square brackets -->  

* [x] I have performed a self-review of my code
* [x] I have tested my changes
* [ ] I have added unit tests that prove my changes work