### PR TITLE
Fix missing table when deleting character

### DIFF
--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -2377,7 +2377,7 @@ public class Character extends AbstractCharacterObject {
                 ps.executeUpdate();
             }
 
-            String[] toDel = {"famelog", "inventoryitems", "keymap", "queststatus", "savedlocations", "trocklocations", "skillmacros", "skills", "eventstats", "server_queue"};
+            String[] toDel = {"famelog", "inventoryitems", "keymap", "queststatus", "savedlocations", "trocklocations", "skillmacros", "skills", "eventstats" };
             for (String s : toDel) {
                 Character.deleteWhereCharacterId(con, "DELETE FROM `" + s + "` WHERE characterid = ?", cid);
             }


### PR DESCRIPTION
## Description

Server error when deleting a character

In-game error:

![in-game-error](https://github.com/user-attachments/assets/bc93fd99-2829-4740-b576-0a792fd1eae3)

Server error:

![console-error](https://github.com/user-attachments/assets/b484ff5f-4dab-421a-8035-6e2fae0a38ec)

The error is caused by the deleting character SQL, which has "missing" `server_queue` table.

I am not sure if this table ever exist or not so the easy fix here is to remove it from the SQL statement.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [ ] I have added unit tests that prove my changes work (I didn't add any test, not sure if it is necessary)
