### PR TITLE
Add support for .env files and setup for database info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Database Configuration
+# Copy this file to .env and fill in your actual database credentials
+# Defaults to config.yaml if not set, remove lines to use config.yaml's values
+DB_HOST=localhost
+DB_USER=root
+DB_PASS=your_password_here
+DB_URL_FORMAT=jdbc:mysql://%s:3306/cosmic

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ database/docker-pg-db-data
 
 # macOS files
 .DS_Store
+
+# Environment variables
+.env

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <liquibase-core.version>4.32.0</liquibase-core.version> <!-- Database migrations -->
         <junit.version>5.13.1</junit.version> <!-- Unit test -->
         <mockito.version>5.18.0</mockito.version> <!-- Unit test -->
+        <dotenv-java.version>3.0.0</dotenv-java.version> <!-- Environment variables from .env file -->
     </properties>
 
     <dependencies>
@@ -81,6 +82,11 @@
             <groupId>net.jcip</groupId>
             <artifactId>jcip-annotations</artifactId>
             <version>${jcip-annotations.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>${dotenv-java.version}</version>
         </dependency>
 
         <!-- Database -->

--- a/src/main/java/tools/DatabaseConnection.java
+++ b/src/main/java/tools/DatabaseConnection.java
@@ -46,18 +46,17 @@ public class DatabaseConnection {
     private static String getDbUrl() {
         // Environment variables override what's defined in the config file
         // This feature is used for the Docker support
-        String hostOverride = System.getenv("DB_HOST");
-        String host = hostOverride != null ? hostOverride : YamlConfig.config.server.DB_HOST;
-        String dbUrl = String.format(YamlConfig.config.server.DB_URL_FORMAT, host);
-        return dbUrl;
+        String host = EnvironmentConfig.get("DB_HOST", YamlConfig.config.server.DB_HOST);
+        String urlFormat = EnvironmentConfig.get("DB_URL_FORMAT", YamlConfig.config.server.DB_URL_FORMAT);
+        return String.format(urlFormat, host);
     }
 
     private static HikariConfig getConfig() {
         HikariConfig config = new HikariConfig();
 
         config.setJdbcUrl(getDbUrl());
-        config.setUsername(YamlConfig.config.server.DB_USER);
-        config.setPassword(YamlConfig.config.server.DB_PASS);
+        config.setUsername(EnvironmentConfig.get("DB_USER", YamlConfig.config.server.DB_USER));
+        config.setPassword(EnvironmentConfig.get("DB_PASS", YamlConfig.config.server.DB_PASS));
 
         final int initFailTimeoutSeconds = YamlConfig.config.server.INIT_CONNECTION_POOL_TIMEOUT;
         config.setInitializationFailTimeout(SECONDS.toMillis(initFailTimeoutSeconds));

--- a/src/main/java/tools/EnvironmentConfig.java
+++ b/src/main/java/tools/EnvironmentConfig.java
@@ -1,0 +1,50 @@
+package tools;
+
+import io.github.cdimascio.dotenv.Dotenv;
+
+/**
+ * Provides access to configuration values from .env files and system environment variables.
+ * Priority order:
+ * 1. .env file values
+ * 2. System environment variables
+ * 3. Provided default value
+ */
+public class EnvironmentConfig {
+    private static final Dotenv dotenv;
+
+    static {
+        dotenv = Dotenv.configure()
+                       .ignoreIfMissing()
+                       .load();
+    }
+
+    /**
+     * Get an environment variable value with fallback to a default.
+     *
+     * @param key the environment variable key
+     * @param defaultValue the default value to use if the variable is not found
+     * @return the environment variable value, or the default if not found
+     */
+    public static String get(String key, String defaultValue) {
+        if (key == null || key.isEmpty()) {
+            return defaultValue;
+        }
+
+        // First try .env file
+        if (dotenv != null) {
+            String value = dotenv.get(key);
+            if (value != null && !value.isEmpty()) {
+                return value;
+            }
+        }
+
+        // Then try system environment
+        String value = System.getenv(key);
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+
+        // Finally use the provided default
+        return defaultValue;
+    }
+}

--- a/src/test/java/tools/EnvironmentConfigTest.java
+++ b/src/test/java/tools/EnvironmentConfigTest.java
@@ -1,0 +1,14 @@
+package tools;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnvironmentConfigTest {
+
+    @Test
+    void getShouldReturnDefaultWhenVariableNotFound() {
+        String value = EnvironmentConfig.get("NONEXISTENT_VARIABLE_XYZ", "my_default");
+        assertEquals("my_default", value);
+    }
+}


### PR DESCRIPTION
## Description

Just picked up this project to experiment. While working, I noticed that I kept having to ignore checking in changes to `config.yaml` that had my plaintext MySQL password.

To make local development a bit safer and more convenient, this adds support for environment variables via a `.env` file. It also adds a `.env.example` file in the repo root that demonstrate supported parameters.

Done through an `EnvironmentManager` class with some helpers.

If I missed an existing/better way to do this, please let me know.

## Checklist before requesting review

* [x] Performed a self-review of the code
* [x] Tested changes locally
* [x] Added unit tests where applicable
