### PR TITLE
Unbloat queststatus table + Improve character save performance

### DIFF
--- a/src/main/java/client/Character.java
+++ b/src/main/java/client/Character.java
@@ -8572,6 +8572,16 @@ public class Character extends AbstractCharacterObject {
                     psStatus.setInt(1, id);
 
                     for (QuestStatus qs : getQuests()) {
+                        // Don't persist pure NOT_STARTED placeholders. getQuest() inserts one into the
+                        // quest map on any lookup, so over time these accumulate and get rewritten on every
+                        // save, bloating the queststatus table. Keep rows carrying real state (forfeit count,
+                        // recorded progress, medal maps); the rest are recreated lazily on demand.
+                        if (qs.getStatus() == QuestStatus.Status.NOT_STARTED
+                                && qs.getForfeited() == 0
+                                && qs.getProgress().isEmpty()
+                                && qs.getMedalMaps().isEmpty()) {
+                            continue;
+                        }
                         psStatus.setInt(2, qs.getQuest().getId());
                         psStatus.setInt(3, qs.getStatus().getId());
                         psStatus.setInt(4, (int) (qs.getCompletionTime() / 1000));


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Current:
queststatus table bloated by rows that simply says "not started", these amount to ~2300 useless rows of delete+insert everytime a character is saved
saving characters takes a long time(relatively, if i have 400+ bots in my server it takes forever(several minutes) to stop/restart) about 1-2 save per second on my machine

Proposed:
Dont put those useless rows in DB, consequently dont reinsert them every saves.

Result:
Much faster save time, very apparent if you have hundreds of characters online and have to restart. 3-4 saves per second on my machine

## Checklist before requesting a review
<!-- Mark with "x" inside the square brackets -->
- [ x] I have performed a self-review of my code
- [x ] I have tested my changes
- [ ] I have added unit tests that prove my changes work

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
