### PR TITLE
feat(chat): add @global world chat command

### DIFF
--- a/src/main/java/client/command/CommandsExecutor.java
+++ b/src/main/java/client/command/CommandsExecutor.java
@@ -30,6 +30,7 @@ import client.command.commands.gm0.DropLimitCommand;
 import client.command.commands.gm0.EnableAuthCommand;
 import client.command.commands.gm0.EquipLvCommand;
 import client.command.commands.gm0.GachaCommand;
+import client.command.commands.gm0.GlobalCommand;
 import client.command.commands.gm0.GmCommand;
 import client.command.commands.gm0.HelpCommand;
 import client.command.commands.gm0.JoinEventCommand;
@@ -346,6 +347,7 @@ public class CommandsExecutor {
         addCommand("credits", StaffCommand.class);
         addCommand("uptime", UptimeCommand.class);
         addCommand("gacha", GachaCommand.class);
+        addCommand("global", GlobalCommand.class);
         addCommand("dispose", DisposeCommand.class);
         addCommand("changel", ChangeLanguageCommand.class);
         addCommand("equiplv", EquipLvCommand.class);

--- a/src/main/java/client/command/commands/gm0/GlobalCommand.java
+++ b/src/main/java/client/command/commands/gm0/GlobalCommand.java
@@ -1,0 +1,46 @@
+/*
+    This file is part of the HeavenMS MapleStory Server, commands OdinMS-based
+    Copyleft (L) 2016 - 2019 RonanLana
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as
+    published by the Free Software Foundation version 3 as published by
+    the Free Software Foundation. You may not use, modify or distribute
+    this program under any other version of the GNU Affero General Public
+    License.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package client.command.commands.gm0;
+
+import client.Character;
+import client.Client;
+import client.command.Command;
+import server.ChatLogger;
+import tools.PacketCreator;
+
+public class GlobalCommand extends Command {
+    {
+        setDescription("Send a message to every player in the world.");
+    }
+
+    @Override
+    public void execute(Client client, String[] params) {
+        Character player = client.getPlayer();
+        String message = player.getLastCommandMessage();
+        if (message == null || message.isBlank()) {
+            player.yellowMessage("Usage: @global <message>");
+            return;
+        }
+
+        String formattedMessage = "[Global] " + player.getName() + ": " + message;
+        client.getWorldServer().broadcastPacket(PacketCreator.serverNotice(6, formattedMessage));
+        ChatLogger.log(client, "Global", message);
+    }
+}

--- a/src/test/java/client/command/commands/gm0/GlobalCommandTest.java
+++ b/src/test/java/client/command/commands/gm0/GlobalCommandTest.java
@@ -1,0 +1,68 @@
+package client.command.commands.gm0;
+
+import client.Character;
+import client.Client;
+import io.netty.buffer.Unpooled;
+import net.packet.ByteBufInPacket;
+import net.packet.Packet;
+import net.server.world.World;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import server.ChatLogger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalCommandTest {
+    @Mock
+    private Client client;
+    @Mock
+    private Character player;
+    @Mock
+    private World world;
+
+    @Test
+    void broadcastsOriginalMessageToTheWholeWorld() {
+        when(client.getPlayer()).thenReturn(player);
+        when(client.getWorldServer()).thenReturn(world);
+        when(player.getName()).thenReturn("RustPocChar");
+        when(player.getLastCommandMessage()).thenReturn("Heading to Henesys");
+
+        try (MockedStatic<ChatLogger> loggerStatic = mockStatic(ChatLogger.class)) {
+            new GlobalCommand().execute(client, new String[]{"heading", "to", "henesys"});
+
+            var packetCaptor = org.mockito.ArgumentCaptor.forClass(Packet.class);
+            verify(world).broadcastPacket(packetCaptor.capture());
+            var packet = new ByteBufInPacket(
+                    Unpooled.wrappedBuffer(packetCaptor.getValue().getBytes()));
+            assertEquals(0x0044, packet.readShort());
+            assertEquals(6, packet.readUnsignedByte());
+            assertEquals("[Global] RustPocChar: Heading to Henesys", packet.readString());
+            assertEquals(0, packet.readInt());
+            assertEquals(0, packet.available());
+            loggerStatic.verify(() -> ChatLogger.log(client, "Global", "Heading to Henesys"));
+        }
+    }
+
+    @Test
+    void rejectsBlankMessagesWithoutBroadcastingOrLogging() {
+        when(client.getPlayer()).thenReturn(player);
+        when(player.getLastCommandMessage()).thenReturn("   ");
+
+        try (MockedStatic<ChatLogger> loggerStatic = mockStatic(ChatLogger.class)) {
+            new GlobalCommand().execute(client, new String[]{});
+
+            verify(player).yellowMessage("Usage: @global <message>");
+            verify(world, never()).broadcastPacket(any(Packet.class));
+            loggerStatic.verifyNoInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## Description
- add a rank-0 `@global <message>` player command
- broadcast a type-6 server notice to every online character in the sender's world
- preserve the sender name and original message casing in `[Global] Name: message`
- log successful messages as `Global` chat and reject blank messages with usage guidance

## Verification
- `./mvnw.cmd -q -Dtest=GlobalCommandTest test`
- `./mvnw.cmd -q test` — 1,888 tests, 0 failures/errors/skips
- `./mvnw.cmd -q -DskipTests package`

Live multi-character verification was not run locally; the unit test decodes and asserts the exact `SERVERMESSAGE` packet sent to the world broadcaster.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested my changes
- [x] I have added unit tests that prove my changes work

## Screenshots
Not applicable.